### PR TITLE
Set appio timeout sec from terraform and not apim named values

### DIFF
--- a/src/api.tf
+++ b/src/api.tf
@@ -1082,8 +1082,9 @@ module "app_io_product" {
   approval_required     = false
 
   policy_xml = templatefile("./api_product/app_io/policy.xml.tmpl", {
-    env_short = var.env_short
-    host_mock = module.apim.gateway_hostname
+    env_short         = var.env_short
+    host_mock         = module.apim.gateway_hostname
+    appio_timeout_sec = var.appio_timeout_sec
   })
 }
 

--- a/src/api_product/app_io/policy.xml.tmpl
+++ b/src/api_product/app_io/policy.xml.tmpl
@@ -8,7 +8,7 @@
         <choose>
             <!-- If API Management doesn’t find it in the cache, make a request for it and store it -->
             <when condition="@(!context.Variables.ContainsKey("fiscalCode"))">
-                <send-request mode="new" response-variable-name="tokenstate" timeout="{{AppIO_Timeout_Sec}}" ignore-error="true">
+                <send-request mode="new" response-variable-name="tokenstate" timeout="${appio_timeout_sec}" ignore-error="true">
                     %{ if env_short != "p" ~}
                       <!--MOCK UAT-->
                       <set-url>@("https://${host_mock}/bpd/pagopa/api/v1/user?token="+(string)context.Variables["token"])</set-url>

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -143,6 +143,12 @@ variable "apim_private_domain" {
   default = "api.cstar.pagopa.it"
 }
 
+variable "appio_timeout_sec" {
+  type        = number
+  description = "AppIo timeout (sec)"
+  default     = 5
+}
+
 variable "pm_backend_host" {
   type        = string
   description = "Payment manager backend host"


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

Reference AppIo Timeout from terraform variable instead of an APIM Named Value

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
