### PR TITLE
Add truncate grant to bpd_citizen

### DIFF
--- a/src/psql/subscriptions/DEV-CSTAR/terraform.tfvars
+++ b/src/psql/subscriptions/DEV-CSTAR/terraform.tfvars
@@ -58,7 +58,7 @@ users = [
         object_type = "table"
         database    = "bpd"
         schema      = "bpd_citizen"
-        privileges  = ["SELECT", "INSERT", "UPDATE", "DELETE"]
+        privileges  = ["SELECT", "INSERT", "UPDATE", "DELETE", "TRUNCATE"]
       },
       {
         object_type = "table"


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->

### Motivation and context

```
Caused by: org.postgresql.util.PSQLException: ERROR: permission denied for relation bpd_citizen_notenabled
  Where: SQL statement "truncate table bpd_citizen.bpd_citizen_notEnabled"
PL/pgSQL function update_bonifica_recesso_citizen(character varying) line 53 at SQL statement
```

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
