### PR TITLE
Fix service url since ingress http

### DIFF
--- a/src/api.tf
+++ b/src/api.tf
@@ -61,7 +61,7 @@ module "api_azureblob" {
   path         = "pagopastorage"
   protocols    = ["https", "http"]
 
-  service_url = format("https://%s/pagopastorage", var.reverse_proxy_ip)
+  service_url = format("http://%s/pagopastorage", var.reverse_proxy_ip)
 
   content_format = "openapi"
   content_value = templatefile("./api/azureblob/openapi.json.tpl", {
@@ -178,7 +178,7 @@ module "api_bpd_io_backend_test" {
   path         = "bpd/pagopa/api/v1"
   protocols    = ["https", "http"]
 
-  service_url = format("https://%s/cstariobackendtest/bpd/pagopa/api/v1", var.reverse_proxy_ip)
+  service_url = format("http://%s/cstariobackendtest/bpd/pagopa/api/v1", var.reverse_proxy_ip)
 
   content_value = templatefile("./api/bpd_io_backend_test/swagger.json.tpl", {
     host = module.apim.gateway_hostname
@@ -352,7 +352,7 @@ module "bpd_hb_citizen_original" {
   path         = "bpd/hb/citizens"
   protocols    = ["https", "http"]
 
-  service_url = format("https://%s/bpdmscitizen/bpd/citizens", var.reverse_proxy_ip)
+  service_url = format("http://%s/bpdmscitizen/bpd/citizens", var.reverse_proxy_ip)
 
   content_value = templatefile("./api/bpd_hb_citizen/original/swagger.json.tpl", {
     host = module.apim.gateway_hostname
@@ -404,7 +404,7 @@ module "bpd_hb_citizen_original_v2" {
   path         = "bpd/hb/citizens"
   protocols    = ["https", "http"]
 
-  service_url = format("https://%s/bpdmscitizen/bpd/citizens", var.reverse_proxy_ip)
+  service_url = format("http://%s/bpdmscitizen/bpd/citizens", var.reverse_proxy_ip)
 
   content_format = "openapi"
   content_value = templatefile(format("./api/bpd_hb_citizen/v2/openapi.json.tpl"), {
@@ -465,7 +465,7 @@ module "bpd_hb_payment_instruments" {
   path         = "bpd/hb/payment-instruments"
   protocols    = ["https", "http"]
 
-  service_url = format("https://%s/bpdmspaymentinstrument/bpd/payment-instruments", var.reverse_proxy_ip)
+  service_url = format("http://%s/bpdmspaymentinstrument/bpd/payment-instruments", var.reverse_proxy_ip)
 
   content_format = "openapi"
   content_value = templatefile("./api/bpd_hb_payment_instruments/original/openapi.json.tpl", {
@@ -580,7 +580,7 @@ module "bpd_hb_payment_instruments_v2" {
   path         = "bpd/hb/payment-instruments"
   protocols    = ["https", "http"]
 
-  service_url = format("https://%s/bpdmspaymentinstrument/bpd/payment-instruments", var.reverse_proxy_ip)
+  service_url = format("http://%s/bpdmspaymentinstrument/bpd/payment-instruments", var.reverse_proxy_ip)
 
   content_format = "openapi"
   content_value = templatefile("./api/bpd_hb_payment_instruments/v2/openapi.json.tpl", {
@@ -653,7 +653,7 @@ module "bpd_hb_winning_transactions" {
   path         = "bpd/hb/winning-transactions"
   protocols    = ["https", "http"]
 
-  service_url = format("https://%s/bpdmswinningtransaction/bpd/winning-transactions", var.reverse_proxy_ip)
+  service_url = format("http://%s/bpdmswinningtransaction/bpd/winning-transactions", var.reverse_proxy_ip)
 
   content_value = templatefile("./api/bpd_hb_winning_transactions/original/swagger.json.tpl", {
     host = module.apim.gateway_hostname
@@ -688,7 +688,7 @@ module "bpd_hb_winning_transactions_v2" {
   path         = "bpd/hb/winning-transactions"
   protocols    = ["https", "http"]
 
-  service_url = format("https://%s/bpd/hb/winning-transactions/v2", var.reverse_proxy_ip)
+  service_url = format("http://%s/bpd/hb/winning-transactions/v2", var.reverse_proxy_ip)
 
   content_format = "openapi"
   content_value = templatefile("./api/bpd_hb_winning_transactions/v2/openapi.json.tpl", {


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

Use http for service url

<!--- Describe your changes in detail -->

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->
![Screenshot 2021-07-06 at 12 31 55](https://user-images.githubusercontent.com/1236551/124585999-2e48aa80-de56-11eb-9fc8-ab5536c057cd.png)


### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
