### PR TITLE
Authorization header check fallback towards io backend if error

### DIFF
--- a/src/api_product/app_io/policy.xml.tmpl
+++ b/src/api_product/app_io/policy.xml.tmpl
@@ -33,9 +33,35 @@
                         <set-variable name="bypassCacheStorage" value="true" />
                     </when>
                     <otherwise>
+                        %{ if env_short != "u" ~}
                         <return-response>
                             <set-status code="401" reason="Unauthorized" />
                         </return-response>
+                        %{ else ~}
+                        <send-request mode="new" response-variable-name="tokenstate" timeout="${appio_timeout_sec}" ignore-error="true">
+                            <set-url>https://app-backend.io.italia.it/bpd/api/v1/user</set-url>
+                            <set-method>GET</set-method>
+                            <set-header name="Authorization" exists-action="override">
+                                <value>@("Bearer " +(string)context.Variables["token"])</value>
+                            </set-header>
+                        </send-request>
+                        <choose>
+                            <when condition="@(context.Variables["tokenstate"] == null)">
+                                <return-response>
+                                    <set-status code="504" reason="Backend IO Timeout" />
+                                </return-response>
+                            </when>
+                            <when condition="@(((IResponse)context.Variables["tokenstate"]).StatusCode == 200)">
+                                <set-variable name="fiscalCode" value="@((string)((IResponse)context.Variables["tokenstate"]).Body.As<JObject>()["fiscal_code"])" />
+                                <set-variable name="bypassCacheStorage" value="true" />
+                            </when>
+                            <otherwise>
+                                <return-response>
+                                    <set-status code="401" reason="Unauthorized" />
+                                </return-response>
+                            </otherwise>
+                        </choose>
+                        %{ endif ~}
                     </otherwise>
                 </choose>
             </when>


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->

### Motivation and context

As requested by Menotti:
"sulla policy dell’APIM di UAT mettiamo il fallback sull’autenticazione, così non dobbiamo neppure switchare alla bisogna:
se token non trovato nel mock --> chiamo backend di IO"

<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
