### PR TITLE
Fix vpn routing to vnet integration

### DIFF
--- a/src/network.tf
+++ b/src/network.tf
@@ -124,9 +124,11 @@ module "vnet_peering" {
   source_resource_group_name       = azurerm_resource_group.rg_vnet.name
   source_virtual_network_name      = module.vnet.name
   source_remote_virtual_network_id = module.vnet.id
+  source_allow_gateway_transit     = true # needed by vpn gateway for enabling routing from vnet to vnet_integration
   target_resource_group_name       = azurerm_resource_group.rg_vnet.name
   target_virtual_network_name      = module.vnet_integration.name
   target_remote_virtual_network_id = module.vnet_integration.id
+  target_use_remote_gateways       = true # needed by vpn gateway for enabling routing from vnet to vnet_integration
 }
 
 ## Application gateway public ip ##


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->

### Motivation and context

Enable routing from vpn gateway to vnet integration

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

`azurevpnconfig.xml` needs these changes:

`prod`  routing to 10.230.6.0/24 is pushed by vpn gateway, no include routes are needed

```xml
    <clientconfig>
        <dnsservers>
            <dnsserver>10.1.134.4</dnsserver>
        </dnsservers>
    </clientconfig>
```

`uat` routing to 10.230.7.0/24 is pushed by vpn gateway, no include routes are needed

```xml
    <clientconfig>
        <dnsservers>
            <dnsserver>10.1.133.4</dnsserver>
        </dnsservers>
    </clientconfig>
```

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
