### PR TITLE
Align rbac to azure ad groups

### DIFF
--- a/src/aks/rbac.tf
+++ b/src/aks/rbac.tf
@@ -2,14 +2,21 @@ data "azuread_group" "adgroup_externals" {
   display_name = format("%s-adgroup-externals", local.project)
 }
 
-data "azuread_group" "adgroup_contributors" {
-  display_name = format("%s-adgroup-contributors", local.project)
+data "azuread_group" "adgroup_developers" {
+  display_name = format("%s-adgroup-developers", local.project)
 }
 
 data "azuread_group" "adgroup_security" {
   display_name = format("%s-adgroup-security", local.project)
 }
 
+data "azuread_group" "adgroup_operations" {
+  display_name = format("%s-adgroup-operations", local.project)
+}
+
+data "azuread_group" "adgroup_technical_project_managers" {
+  display_name = format("%s-adgroup-technical-project-managers", local.project)
+}
 
 resource "kubernetes_cluster_role" "view_extra" {
   metadata {
@@ -58,6 +65,18 @@ resource "kubernetes_cluster_role_binding" "view_extra_binding" {
     name      = data.azuread_group.adgroup_externals.object_id
     namespace = "kube-system"
   }
+
+  subject {
+    kind      = "Group"
+    name      = data.azuread_group.adgroup_operations.object_id
+    namespace = "kube-system"
+  }
+
+  subject {
+    kind      = "Group"
+    name      = data.azuread_group.adgroup_technical_project_managers.object_id
+    namespace = "kube-system"
+  }
 }
 
 resource "kubernetes_cluster_role_binding" "edit_binding" {
@@ -73,7 +92,7 @@ resource "kubernetes_cluster_role_binding" "edit_binding" {
 
   subject {
     kind      = "Group"
-    name      = data.azuread_group.adgroup_contributors.object_id
+    name      = data.azuread_group.adgroup_developers.object_id
     namespace = "kube-system"
   }
 }
@@ -98,6 +117,18 @@ resource "kubernetes_cluster_role_binding" "view_binding" {
   subject {
     kind      = "Group"
     name      = data.azuread_group.adgroup_externals.object_id
+    namespace = "kube-system"
+  }
+
+  subject {
+    kind      = "Group"
+    name      = data.azuread_group.adgroup_operations.object_id
+    namespace = "kube-system"
+  }
+
+  subject {
+    kind      = "Group"
+    name      = data.azuread_group.adgroup_technical_project_managers.object_id
     namespace = "kube-system"
   }
 }


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

update aks rbac
- rename contributors group to developers
- add operations group
- add technical-project-managers group

### Motivation and context

align aks rbac with azure ad groups https://github.com/pagopa/pagopa-authorization/pull/63

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
