### PR TITLE
Add default resource group for role assignment

### DIFF
--- a/src/default.tf
+++ b/src/default.tf
@@ -1,4 +1,5 @@
 resource "azurerm_resource_group" "default_roleassignment_rg" {
+  #Important: do not create any resource inside this resource group
   name     = "default-roleassignment-rg"
   location = var.location
 

--- a/src/default.tf
+++ b/src/default.tf
@@ -1,0 +1,6 @@
+resource "azurerm_resource_group" "roleassignment_default_rg" {
+  name     = "roleassignment-default-rg"
+  location = var.location
+
+  tags = var.tags
+}

--- a/src/default.tf
+++ b/src/default.tf
@@ -1,5 +1,5 @@
-resource "azurerm_resource_group" "roleassignment_default_rg" {
-  name     = "roleassignment-default-rg"
+resource "azurerm_resource_group" "default_roleassignment_rg" {
+  name     = "default-roleassignment-rg"
   location = var.location
 
   tags = var.tags


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

add fake `default-roleassignment-rg`

### Motivation and context

A service principal or user need to access at least one resource inside a subscription.
`default-roleassignment-rg` it's a fake resource

### Type of changes

- [x] Add new resources
- [ ] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
