### PR TITLE
[CEN-666] Fix Postgres Configuration

### DIFF
--- a/src/env/dev/terraform.tfvars
+++ b/src/env/dev/terraform.tfvars
@@ -220,13 +220,13 @@ azdo_sp_tls_cert_enabled            = true
 db_sku_name       = "GP_Gen5_2"
 db_enable_replica = false
 db_configuration = {
-  autovacuum_work_mem         = "2000000"
-  effective_cache_size        = "10485760"
+  autovacuum_work_mem         = "-1"
+  effective_cache_size        = "655360"
   log_autovacuum_min_duration = "5000"
   log_connections             = "off"
   log_line_prefix             = "%t [%p apps:%a host:%r]: [%l-1] db=%d,user=%u"
   log_temp_files              = "4096"
-  maintenance_work_mem        = "1048576"
+  maintenance_work_mem        = "524288"
   max_wal_size                = "4096"
 }
 

--- a/src/env/prod/terraform.tfvars
+++ b/src/env/prod/terraform.tfvars
@@ -222,13 +222,13 @@ db_geo_redundant_backup_enabled = false
 db_enable_replica               = true
 db_storage_mb                   = 5242880 # 5TB
 db_configuration = {
-  autovacuum_work_mem         = "2000000"
-  effective_cache_size        = "10485760"
+  autovacuum_work_mem         = "-1"
+  effective_cache_size        = "5242880"
   log_autovacuum_min_duration = "5000"
   log_connections             = "off"
   log_line_prefix             = "%t [%p apps:%a host:%r]: [%l-1] db=%d,user=%u"
   log_temp_files              = "4096"
-  maintenance_work_mem        = "1048576"
+  maintenance_work_mem        = "524288"
   max_wal_size                = "4096"
 }
 db_replica_network_rules = {

--- a/src/env/uat/terraform.tfvars
+++ b/src/env/uat/terraform.tfvars
@@ -222,13 +222,13 @@ db_sku_name       = "GP_Gen5_8"
 db_enable_replica = false
 db_storage_mb     = 204800 # 200 GB
 db_configuration = {
-  autovacuum_work_mem         = "2000000"
-  effective_cache_size        = "10485760"
+  autovacuum_work_mem         = "-1"
+  effective_cache_size        = "2621440"
   log_autovacuum_min_duration = "5000"
   log_connections             = "off"
   log_line_prefix             = "%t [%p apps:%a host:%r]: [%l-1] db=%d,user=%u"
   log_temp_files              = "4096"
-  maintenance_work_mem        = "1048576"
+  maintenance_work_mem        = "524288"
   max_wal_size                = "4096"
 }
 db_network_rules = {


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

This PR proposes to fix some configuration variables related to Postgres memory management after the scale down of the prod environment. The same rationale is applied to other envs (dev and uat) to fix the configuration.

### List of changes

<!--- Describe your changes in detail -->

- Set `effective_cache_size = 0.5 x Tot RAM` (this reference suggests 0.7 x Tot RAM, but 0.5 is more conservative https://www.cybertec-postgresql.com/en/effective_cache_size-what-it-means-in-postgresql/ )

- Halved `maintenance_work_mem`, as the RAM of the DBMS has been halved (this setting is kept constant in all environment)

- Set `autovacuum_work_mem = -1`, with this setting the autovacuum work memory is managed by the DBMS from 0 to `autovacuum_max_workers x maintenance_work_mem`

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

While migrating the system, configuration of the DBMS  has been mirrored in our subscription, but all environments have been set to SIA production settings, which are inadequate for lower environments. Moreover, production DB has been scaled down, so configuration must be changed accordingly.

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
