### PR TITLE
[CEN-746] Add Horizontal Autoscaler for citizen deployment

### DIFF
--- a/src/k8s/bpd_deployments.tf
+++ b/src/k8s/bpd_deployments.tf
@@ -1,0 +1,18 @@
+resource "kubernetes_horizontal_pod_autoscaler" "bpd_citizen_has" {
+  metadata {
+    name      = "bpdcitizenhas" # has suffix stands for Horizontal AutoScaler
+    namespace = kubernetes_namespace.bpd.metadata[0].name
+  }
+
+  # standard metric is CPU utilization by pods
+  spec {
+    max_replicas = 10
+    min_replicas = 1
+
+    scale_target_ref {
+      kind = "Deployment"
+      # Deployment name and definition is reported in microservice repository
+      name = "bpdmscitizen" 
+    }
+  }
+}


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

This PR proposes to use the resource `kubernetes_horizontal_pod_autoscaler` to link number of pods in a deployment to CPU load, which in turn is related to system load.

### List of changes

<!--- Describe your changes in detail -->
- A new Horizontal Pod Autoscaler for citizen deployment
### Motivation and context

<!--- Why is this change required? What problem does it solve? -->
Pod autoscaling is an effective way to reduce cluster costs


### Type of changes

- [x] Add new resources
- [ ] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
