### PR TITLE
[CEN-799] Fix aks version and max_pods input

### DIFF
--- a/src/aks.tf
+++ b/src/aks.tf
@@ -5,7 +5,7 @@ resource "azurerm_resource_group" "rg_aks" {
 }
 
 module "aks" {
-  source = "git::https://github.com/pagopa/azurerm.git//kubernetes_cluster?ref=v1.0.58"
+  source = "git::https://github.com/pagopa/azurerm.git//kubernetes_cluster?ref=v1.0.60"
 
   name                       = format("%s-aks", local.project)
   location                   = azurerm_resource_group.rg_aks.location
@@ -18,6 +18,7 @@ module "aks" {
   vm_size    = var.aks_vm_size
   node_count = var.aks_node_count
   sku_tier   = var.aks_sku_tier
+  max_pods   = var.env_short == "d"? 100 : 30
 
   private_cluster_enabled = true
 


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
This PR proposes to upgrade version of `kubernetes_cluster` custom module to support `max_pods` as input

### List of changes

<!--- Describe your changes in detail -->
- Upgrade version of `kubernetes_cluster` custom module 

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

This upgrade is needed because I had to recreate via `az cli` a nodepool in the cluster supporting `max_pods = 100`.  Since `max_pods` is now different from the number (30) stored in TF state, Terraform tries to destroy and recreate the cluster without this fix

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [x] Yes
- [ ] No

Terraform plan after this fix should result in a `Nothing To Change` status, but I get the following minor modification, which can be safely applied as far as I know

```
      ~ upgrade_settings {
              ~ max_surge = "33" -> "33%"
            }
        }
```

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
