### PR TITLE
[CEN-816] Set external cache on APP_IO product

### DIFF
--- a/src/api_product/app_io/policy.xml.tmpl
+++ b/src/api_product/app_io/policy.xml.tmpl
@@ -3,7 +3,7 @@
         <!-- Extract Token from Authorization header parameter -->
         <set-variable name="token" value="@(context.Request.Headers.GetValueOrDefault("Authorization","scheme param").Split(' ').Last())" />
         <!--set-variable name="token" value="@(context.Request.Headers.GetValueOrDefault("Authorization","scheme param"))" /-->
-        <cache-lookup-value key="@((string)context.Variables["token"])" variable-name="fiscalCode" caching-type="internal" />
+        <cache-lookup-value key="@((string)context.Variables["token"])" variable-name="fiscalCode" caching-type="external" />
         <set-variable name="bypassCacheStorage" value="false" />
         <choose>
             <!-- If API Management doesn’t find it in the cache, make a request for it and store it -->
@@ -90,7 +90,7 @@
                 <choose>
                     <when condition="@("true".Equals((string)context.Variables["bypassCacheStorage"]))">
                         <!-- Store result in cache -->
-                        <cache-store-value key="@((string)context.Variables["token"])" value="@((string)context.Variables["fiscalCode"])" duration="3600" caching-type="internal" />
+                        <cache-store-value key="@((string)context.Variables["token"])" value="@((string)context.Variables["fiscalCode"])" duration="3600" caching-type="external" />
                     </when>
                 </choose>
             </otherwise>


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
This PR proposes to set the APIM cache for APP_IO product to `external`

### List of changes

<!--- Describe your changes in detail -->
- Set `caching-type=external` in policy template of app io product

### Motivation and context

Since the apis of this product store in cache the fiscal code, under high load the apim internal cache could reach its limit

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Please note that the cache is set to internal in many other endpoints, as reported by the following full text search on repo, but in that cases the requested cache doesn't increment with load. I don't know the original settings of the APIM prior to migration

<img width="810" alt="Schermata 2021-10-08 alle 09 33 44" src="https://user-images.githubusercontent.com/8901084/136518417-2ca163da-0f34-440f-b8bb-85bab01d0f99.png">

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
