### PR TITLE
[CEN-813] Add EventHub fa-trx-error

### DIFF
--- a/src/env/dev/terraform.tfvars
+++ b/src/env/dev/terraform.tfvars
@@ -474,6 +474,26 @@ eventhubs = [
     ]
   },
   {
+    name              = "fa-trx-error"
+    partitions        = 1
+    message_retention = 1
+    consumers         = ["fa-transaction-error-manager"]
+    keys = [
+      {
+        name   = "fa-transaction"
+        listen = false
+        send   = true
+        manage = false
+      },
+      {
+        name   = "fa-transaction-error-manager"
+        listen = true
+        send   = false
+        manage = false
+      }
+    ]
+  },
+  {
     name              = "rtd-trx"
     partitions        = 1
     message_retention = 1

--- a/src/env/prod/terraform.tfvars
+++ b/src/env/prod/terraform.tfvars
@@ -487,6 +487,26 @@ eventhubs = [
     ]
   },
   {
+    name              = "fa-trx-error"
+    partitions        = 3
+    message_retention = 7
+    consumers         = ["fa-transaction-error-manager"]
+    keys = [
+      {
+        name   = "fa-transaction"
+        listen = false
+        send   = true
+        manage = false
+      },
+      {
+        name   = "fa-transaction-error-manager"
+        listen = true
+        send   = false
+        manage = false
+      }
+    ]
+  },
+  {
     name              = "rtd-trx"
     partitions        = 32
     message_retention = 7

--- a/src/env/uat/terraform.tfvars
+++ b/src/env/uat/terraform.tfvars
@@ -484,6 +484,26 @@ eventhubs = [
     ]
   },
   {
+    name              = "fa-trx-error"
+    partitions        = 1
+    message_retention = 1
+    consumers         = ["fa-transaction-error-manager"]
+    keys = [
+      {
+        name   = "fa-transaction"
+        listen = false
+        send   = true
+        manage = false
+      },
+      {
+        name   = "fa-transaction-error-manager"
+        listen = true
+        send   = false
+        manage = false
+      }
+    ]
+  },
+  {
     name              = "rtd-trx"
     partitions        = 1
     message_retention = 1


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
This PR proposes to add the queue `fa-trx-error` to the existing eventhub namespace in all environments

### List of changes

<!--- Describe your changes in detail -->
- Modify `eventhubs` TF var in all environments to add a new queue `fa-trx-error`

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->
This change is required to allow the communication between `fa-transaction` and `fa-transaction-error` microservices 

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
