### PR TITLE
[CEN-829] New EventHub Namespace for FA

### DIFF
--- a/src/messages.tf
+++ b/src/messages.tf
@@ -7,8 +7,7 @@ resource "azurerm_resource_group" "msg_rg" {
 
 
 module "event_hub" {
-  # source                   = "git::https://github.com/pagopa/azurerm.git//eventhub?ref=v1.0.51"
-  source                   = "git::https://github.com/pagopa/azurerm.git//eventhub?ref=CEN-828-refactor-eventhub-module"
+  source                   = "git::https://github.com/pagopa/azurerm.git//eventhub?ref=v1.0.70"
   name                     = format("%s-evh-ns", local.project)
   location                 = var.location
   resource_group_name      = azurerm_resource_group.msg_rg.name
@@ -53,8 +52,8 @@ resource "azurerm_key_vault_secret" "event_hub_keys" {
 
 
 module "event_hub_fa_01" {
-  # source                   = "git::https://github.com/pagopa/azurerm.git//eventhub?ref=v1.0.51"
-  source                   = "git::https://github.com/pagopa/azurerm.git//eventhub?ref=CEN-828-refactor-eventhub-module"
+  source                   = "git::https://github.com/pagopa/azurerm.git//eventhub?ref=v1.0.70"
+  
 
   name                     = format("%s-evh-ns-fa-01", local.project)
   location                 = var.location


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
This PR proposes to create a new EventHub Namespace for FA

### List of changes

<!--- Describe your changes in detail -->
- New Namespace
- New Secrets in Key Vault for connection strings

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

This PR is motivated by the fact that the existing `eventhub` namespace can contain a maximum of `10` queues but BPD + FA + RTD need more. Scaling to `Premium` SKU isn't an option, due to an excessive cost increase (10x)

### Type of changes

- [x] Add new resources
- [ ] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

This PR relies on a new version of the `eventhub` module which must still be released 

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
