### PR TITLE
[CEN-848] Fix connection string of consumers and producers of FA eventhubs

### DIFF
--- a/src/env/dev/terraform.tfvars
+++ b/src/env/dev/terraform.tfvars
@@ -477,7 +477,7 @@ eventhubs = [
     name              = "rtd-trx"
     partitions        = 1
     message_retention = 1
-    consumers         = ["bpd-payment-instrument"]
+    consumers         = ["bpd-payment-instrument", "rtd-trx-fa-comsumer-group"]
     keys = [
       {
         name   = "rtd-csv-connector"
@@ -489,6 +489,18 @@ eventhubs = [
         name   = "bpd-payment-instrument"
         listen = true
         send   = false
+        manage = false
+      },
+      {
+        name   = "rtd-trx-consumer"
+        listen = true
+        send   = false
+        manage = false
+      },
+      {
+        name   = "rtd-trx-producer"
+        listen = false
+        send   = true
         manage = false
       }
     ]
@@ -520,16 +532,16 @@ eventhubs_fa = [
     name              = "fa-trx-error"
     partitions        = 1
     message_retention = 1
-    consumers         = ["fa-transaction-error-manager"]
+    consumers         = ["fa-trx-error-consumer-group"]
     keys = [
       {
-        name   = "fa-transaction"
+        name   = "fa-trx-error-producer"
         listen = false
         send   = true
         manage = false
       },
       {
-        name   = "fa-transaction-error-manager"
+        name   = "fa-trx-error-consumer"
         listen = true
         send   = false
         manage = false
@@ -540,16 +552,16 @@ eventhubs_fa = [
     name              = "fa-trx"
     partitions        = 1
     message_retention = 1
-    consumers         = ["fa-transaction"]
+    consumers         = ["fa-trx-consumer-group"]
     keys = [
       {
-        name   = "fa-merchant"
+        name   = "fa-trx-producer"
         listen = false
         send   = true
         manage = false
       },
       {
-        name   = "fa-transaction"
+        name   = "fa-trx-consumer"
         listen = true
         send   = false
         manage = false
@@ -560,16 +572,16 @@ eventhubs_fa = [
     name              = "fa-trx-merchant"
     partitions        = 1
     message_retention = 1
-    consumers         = ["fa-merchant"]
+    consumers         = ["fa-trx-merchant-consumer-group"]
     keys = [
       {
-        name   = "fa-customer"
+        name   = "fa-trx-merchant-producer"
         listen = false
         send   = true
         manage = false
       },
       {
-        name   = "fa-merchant"
+        name   = "fa-trx-merchant-consumer"
         listen = true
         send   = false
         manage = false
@@ -580,16 +592,16 @@ eventhubs_fa = [
     name              = "fa-trx-customer"
     partitions        = 1
     message_retention = 1
-    consumers         = ["fa-customer"]
+    consumers         = ["fa-trx-customer-consumer-group"]
     keys = [
       {
-        name   = "fa-payment-instrument"
+        name   = "fa-trx-customer-producer"
         listen = false
         send   = true
         manage = false
       },
       {
-        name   = "fa-customer"
+        name   = "fa-trx-customer-consumer"
         listen = true
         send   = false
         manage = false

--- a/src/env/prod/terraform.tfvars
+++ b/src/env/prod/terraform.tfvars
@@ -490,7 +490,7 @@ eventhubs = [
     name              = "rtd-trx"
     partitions        = 32
     message_retention = 7
-    consumers         = ["bpd-payment-instrument"]
+    consumers         = ["bpd-payment-instrument", "rtd-trx-fa-comsumer-group"]
     keys = [
       {
         name   = "rtd-csv-connector"
@@ -502,6 +502,18 @@ eventhubs = [
         name   = "bpd-payment-instrument"
         listen = true
         send   = false
+        manage = false
+      },
+      {
+        name   = "rtd-trx-consumer"
+        listen = true
+        send   = false
+        manage = false
+      },
+      {
+        name   = "rtd-trx-producer"
+        listen = false
+        send   = true
         manage = false
       }
     ]
@@ -530,20 +542,20 @@ eventhubs = [
 
 
 eventhubs_fa = [
-  {
+    {
     name              = "fa-trx-error"
-    partitions        = 3
+    partitions        = 1
     message_retention = 7
-    consumers         = ["fa-transaction-error-manager"]
+    consumers         = ["fa-trx-error-consumer-group"]
     keys = [
       {
-        name   = "fa-transaction"
+        name   = "fa-trx-error-producer"
         listen = false
         send   = true
         manage = false
       },
       {
-        name   = "fa-transaction-error-manager"
+        name   = "fa-trx-error-consumer"
         listen = true
         send   = false
         manage = false
@@ -552,18 +564,18 @@ eventhubs_fa = [
   },
   {
     name              = "fa-trx"
-    partitions        = 16
+    partitions        = 1
     message_retention = 7
-    consumers         = ["fa-transaction"]
+    consumers         = ["fa-trx-consumer-group"]
     keys = [
       {
-        name   = "fa-merchant"
+        name   = "fa-trx-producer"
         listen = false
         send   = true
         manage = false
       },
       {
-        name   = "fa-transaction"
+        name   = "fa-trx-consumer"
         listen = true
         send   = false
         manage = false
@@ -572,18 +584,18 @@ eventhubs_fa = [
   },
   {
     name              = "fa-trx-merchant"
-    partitions        = 8
+    partitions        = 1
     message_retention = 7
-    consumers         = ["fa-merchant"]
+    consumers         = ["fa-trx-merchant-consumer-group"]
     keys = [
       {
-        name   = "fa-customer"
+        name   = "fa-trx-merchant-producer"
         listen = false
         send   = true
         manage = false
       },
       {
-        name   = "fa-merchant"
+        name   = "fa-trx-merchant-consumer"
         listen = true
         send   = false
         manage = false
@@ -592,18 +604,18 @@ eventhubs_fa = [
   },
   {
     name              = "fa-trx-customer"
-    partitions        = 8
+    partitions        = 1
     message_retention = 7
-    consumers         = ["fa-customer"]
+    consumers         = ["fa-trx-customer-consumer-group"]
     keys = [
       {
-        name   = "fa-payment-instrument"
+        name   = "fa-trx-customer-producer"
         listen = false
         send   = true
         manage = false
       },
       {
-        name   = "fa-customer"
+        name   = "fa-trx-customer-consumer"
         listen = true
         send   = false
         manage = false

--- a/src/env/uat/terraform.tfvars
+++ b/src/env/uat/terraform.tfvars
@@ -487,7 +487,7 @@ eventhubs = [
     name              = "rtd-trx"
     partitions        = 1
     message_retention = 1
-    consumers         = ["bpd-payment-instrument"]
+    consumers         = ["bpd-payment-instrument", "rtd-trx-fa-comsumer-group"]
     keys = [
       {
         name   = "rtd-csv-connector"
@@ -499,6 +499,18 @@ eventhubs = [
         name   = "bpd-payment-instrument"
         listen = true
         send   = false
+        manage = false
+      },
+      {
+        name   = "rtd-trx-consumer"
+        listen = true
+        send   = false
+        manage = false
+      },
+      {
+        name   = "rtd-trx-producer"
+        listen = false
+        send   = true
         manage = false
       }
     ]
@@ -530,16 +542,16 @@ eventhubs_fa = [
     name              = "fa-trx-error"
     partitions        = 1
     message_retention = 1
-    consumers         = ["fa-transaction-error-manager"]
+    consumers         = ["fa-trx-error-consumer-group"]
     keys = [
       {
-        name   = "fa-transaction"
+        name   = "fa-trx-error-producer"
         listen = false
         send   = true
         manage = false
       },
       {
-        name   = "fa-transaction-error-manager"
+        name   = "fa-trx-error-consumer"
         listen = true
         send   = false
         manage = false
@@ -550,16 +562,16 @@ eventhubs_fa = [
     name              = "fa-trx"
     partitions        = 1
     message_retention = 1
-    consumers         = ["fa-transaction"]
+    consumers         = ["fa-trx-consumer-group"]
     keys = [
       {
-        name   = "fa-merchant"
+        name   = "fa-trx-producer"
         listen = false
         send   = true
         manage = false
       },
       {
-        name   = "fa-transaction"
+        name   = "fa-trx-consumer"
         listen = true
         send   = false
         manage = false
@@ -570,16 +582,16 @@ eventhubs_fa = [
     name              = "fa-trx-merchant"
     partitions        = 1
     message_retention = 1
-    consumers         = ["fa-merchant"]
+    consumers         = ["fa-trx-merchant-consumer-group"]
     keys = [
       {
-        name   = "fa-customer"
+        name   = "fa-trx-merchant-producer"
         listen = false
         send   = true
         manage = false
       },
       {
-        name   = "fa-merchant"
+        name   = "fa-trx-merchant-consumer"
         listen = true
         send   = false
         manage = false
@@ -590,16 +602,16 @@ eventhubs_fa = [
     name              = "fa-trx-customer"
     partitions        = 1
     message_retention = 1
-    consumers         = ["fa-customer"]
+    consumers         = ["fa-trx-customer-consumer-group"]
     keys = [
       {
-        name   = "fa-payment-instrument"
+        name   = "fa-trx-customer-producer"
         listen = false
         send   = true
         manage = false
       },
       {
-        name   = "fa-customer"
+        name   = "fa-trx-customer-consumer"
         listen = true
         send   = false
         manage = false


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
This PR proposes to rename connection strings of FA eventhubs and add two more general connection strings to `rtd-trx` eventhub

### List of changes

<!--- Describe your changes in detail -->
- rename consumer groups on FA eventhubs
- add a consumer group on `rtd-trx` eventhub
- rename connection strings on FA eventhubs to support a more general naming scheme capable of reusing connections on different micro-services 
- add two connection strings on `rtd-trx` eventhub


### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

This PR is motivated by the fact that a more general naming scheme for connection strings allow to reuse eventhub connections on different microservices 

### Type of changes

- [x] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
Applied manually due to known _purge_  permission issue non key vault