### PR TITLE
[CEN-901] Grant admin permissions on dev k8s to externals

### DIFF
--- a/src/aks.tf
+++ b/src/aks.tf
@@ -23,7 +23,7 @@ module "aks" {
   private_cluster_enabled = true
 
   rbac_enabled        = true
-  aad_admin_group_ids = var.env_short == "d" ? [data.azuread_group.adgroup_admin.object_id, data.azuread_group.adgroup_developers.object_id] : [data.azuread_group.adgroup_admin.object_id]
+  aad_admin_group_ids = var.env_short == "d" ? [data.azuread_group.adgroup_admin.object_id, data.azuread_group.adgroup_developers.object_id, data.azuread_group.adgroup_externals.object_id] : [data.azuread_group.adgroup_admin.object_id]
 
   vnet_id        = module.vnet.id
   vnet_subnet_id = module.k8s_snet.id


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
This PR proposes to grant administrative permissions on k8s cluster in dev subscription to members of the `external` group.

### List of changes

<!--- Describe your changes in detail -->
- Extend admins on `aks` in dev subscription

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->
This PR is needed to allow members of the external group to perform daily activities such as restarting pods

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [X] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

Plan detected changes on dev application gateway

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
