### PR TITLE
Fixed wrong assigment of env var in configmaps

### DIFF
--- a/src/k8s/subscriptions/DEV-CSTAR/terraform.tfvars
+++ b/src/k8s/subscriptions/DEV-CSTAR/terraform.tfvars
@@ -237,7 +237,6 @@ configmaps_faenrollment = {
   POSTGRES_POOLSIZE                                 = "2"
   POSTGRES_SHOW_SQL                                 = "true"
   LOG_LEVEL_FA_ENROLLMENT                           = "DEBUG"
-  MS_AGENZIA_ENTRATE_HOST                           = "cstariobackendtest"
 }
 
 configmaps_fapaymentinstrument = {
@@ -274,6 +273,7 @@ configmaps_fainvoicemanager = {
   POSTGRES_POOLSIZE                                 = "2"
   POSTGRES_SHOW_SQL                                 = "true"
   LOG_LEVEL_FA_INVOICE_MANAGER                      = "DEBUG"
+  MS_AGENZIA_ENTRATE_HOST                           = "cstariobackendtest"
 }
 
 configmaps_fainvoiceprovider = {


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->
- Remove env var from Enrollment's configmap
- Add env var in Invoice Manager's configmap

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->
This change is mandatory to invoke APIs exposed by Mock MicroService

### Type of changes

- [x] Add new resources
- [ ] Update configuration to existing resources
- [x] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [x] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [x] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
