### PR TITLE
set ingress ip to invoke bpd's mock api

### DIFF
--- a/src/k8s/fa_configmaps.tf
+++ b/src/k8s/fa_configmaps.tf
@@ -49,10 +49,15 @@ resource "kubernetes_config_map" "famstransaction" {
   data = merge({
     POSTGRES_SCHEMA            = "fa_transaction"
     TZ                         = "Europe/Rome"
-    KAFKA_RTDTX_TOPIC          = "fa-trx"
-    KAFKA_RTDTX_GROUP_ID       = "fa-transaction"
+    KAFKA_VLDTRX_TOPIC         = "rtd-trx"
+    KAFKA_VLDTRX_GROUP_ID      = "fa-transaction"
+    KAFKA_TRX_TOPIC            = "fa-trx"
+    KAFKA_TRX_GROUP_ID         = "fa-transaction"
+    KAFKA_PMNSTRTRX_TOPIC      = "fa-trx-payment-instrument"
+    KAFKA_PMNSTRTRX_GROUP_ID   = "fa-transaction"
     KAFKA_FATRX_ERROR_TOPIC    = "fa-trx-error"
     KAFKA_FATRX_ERROR_GROUP_ID = "fa-transaction"
+    KAFKA_SERVERS_RTD          = local.event_hub_connection
   }, var.configmaps_fatransaction)
 
 }
@@ -78,12 +83,10 @@ resource "kubernetes_config_map" "famspaymentinstrument" {
   data = merge({
     POSTGRES_SCHEMA            = "fa_payment_instrument"
     TZ                         = "Europe/Rome"
-    KAFKA_RTDTX_TOPIC          = "rtd-trx"
-    KAFKA_RTDTX_GROUP_ID       = "fa-payment-instrument"
+    KAFKA_PAYINSTRTRX_TOPIC    = "fa-trx-payment-instrument"
+    KAFKA_PAYINSTRTRX_GROUP_ID = "fa-payment-instrument"
     KAFKA_CUSTOMERTRX_TOPIC    = "fa-trx-customer"
     KAFKA_CUSTOMERTRX_GROUP_ID = "fa-payment-instrument"
-    KAFKA_SERVERS_RTD          = local.event_hub_connection
-    KAFKA_SERVERS              = local.event_hub_connection_fa_01
   }, var.configmaps_fapaymentinstrument)
 
 }
@@ -124,7 +127,8 @@ resource "kubernetes_config_map" "famsinvoicemanager" {
   }
 
   data = merge({
-    TZ = "Europe/Rome"
+    TZ                      = "Europe/Rome"
+    MS_AGENZIA_ENTRATE_HOST = (var.env_short =="d" ? format("%s/cstariobackendtest", var.ingress_load_balancer_ip) : "")
   }, var.configmaps_fainvoicemanager)
 
 }
@@ -166,7 +170,7 @@ resource "kubernetes_config_map" "famstransactionerrormanager" {
   }
 
   data = merge({
-    POSTGRES_SCHEMA         = "fa_customer"
+    POSTGRES_SCHEMA         = "fa_error_record"
     TZ                      = "Europe/Rome"
     KAFKA_FATXERR_TOPIC     = "fa-trx-error"
     KAFKA_FATXERR_GROUP_ID  = "fa-transaction-error-manager"
@@ -177,7 +181,6 @@ resource "kubernetes_config_map" "famstransactionerrormanager" {
     KAFKA_RTDTRX_TOPIC      = "rtd-trx"
     KAFKA_RTDTRX_GROUP_ID   = "fa-transaction-error-manager"
     KAFKA_SERVERS_RTD       = local.event_hub_connection
-    KAFKA_SERVERS           = local.event_hub_connection_fa_01
   }, var.configmaps_fatransactionerrormanager)
 
 }

--- a/src/k8s/fa_secrets.tf
+++ b/src/k8s/fa_secrets.tf
@@ -73,7 +73,7 @@ resource "kubernetes_secret" "famspaymentinstrument" {
 
   data = {
     #Kafka Connection String Consumer
-    KAFKA_RTDTX_SASL_JAAS_CONFIG          = format(local.jaas_config_template, "rtd-trx", "rtd-trx-consumer", module.key_vault_secrets_query.values["evh-rtd-trx-rtd-trx-consumer-key"].value)
+    KAFKA_PAYINSTRTRX_SASL_JAAS_CONFIG    = format(local.jaas_config_template_fa, "fa-trx-payment-instrument", "fa-trx-payment-instrument-consumer", module.key_vault_secrets_query.values["evh-fa-trx-payment-instrument-fa-trx-payment-instrument-consumer-key-fa-01"].value)
 
     #Kafka Connection String Producer
     KAFKA_CUSTOMERTRX_SASL_JAAS_CONFIG    = format(local.jaas_config_template_fa, "fa-trx-customer", "fa-trx-customer-producer", module.key_vault_secrets_query.values["evh-fa-trx-customer-fa-trx-customer-producer-key-fa-01"].value)
@@ -91,10 +91,17 @@ resource "kubernetes_secret" "famstransaction" {
 
   data = {
     #Kafka Connection String Consumer
-    KAFKA_FATRX_SASL_JAAS_CONFIG          = format(local.jaas_config_template_fa, "fa-trx", "fa-trx-consumer", module.key_vault_secrets_query.values["evh-fa-trx-fa-trx-consumer-key-fa-01"].value)
+    KAFKA_TRX_SASL_JAAS_CONFIG            = format(local.jaas_config_template_fa, "fa-trx", "fa-trx-consumer", module.key_vault_secrets_query.values["evh-fa-trx-fa-trx-consumer-key-fa-01"].value)
+
+    #Kafka Connection String Consumer
+    KAFKA_VLDTRX_SASL_JAAS_CONFIG         = format(local.jaas_config_template, "rtd-trx", "rtd-trx-consumer", module.key_vault_secrets_query.values["evh-rtd-trx-rtd-trx-consumer-key"].value)
 
     #Kafka Connection String Producer
     KAFKA_FATRX_ERROR_SASL_JAAS_CONFIG    = format(local.jaas_config_template_fa, "fa-trx-error", "fa-trx-error-producer", module.key_vault_secrets_query.values["evh-fa-trx-error-fa-trx-error-producer-key-fa-01"].value)
+
+    #Kafka Connection String Producer
+    KAFKA_PMNSTRTRX_SASL_JAAS_CONFIG      = format(local.jaas_config_template_fa, "fa-trx-payment-instrument", "fa-trx-payment-instrument-producer", module.key_vault_secrets_query.values["evh-fa-trx-payment-instrument-fa-trx-payment-instrument-producer-key-fa-01"].value)
+
     APPLICATIONINSIGHTS_CONNECTION_STRING = local.appinsights_instrumentation_key
   }
 

--- a/src/k8s/secrets.tf
+++ b/src/k8s/secrets.tf
@@ -46,6 +46,8 @@ module "key_vault_secrets_query" {
     "evh-fa-trx-error-fa-trx-error-consumer-key-fa-01",
     "evh-fa-trx-fa-trx-producer-key-fa-01",
     "evh-fa-trx-customer-fa-trx-customer-producer-key-fa-01",
-    "evh-rtd-trx-rtd-trx-producer-key"
+    "evh-rtd-trx-rtd-trx-producer-key",
+    "evh-fa-trx-payment-instrument-fa-trx-payment-instrument-consumer-key-fa-01",
+    "evh-fa-trx-payment-instrument-fa-trx-payment-instrument-producer-key-fa-01"
   ]
 }

--- a/src/k8s/subscriptions/DEV-CSTAR/terraform.tfvars
+++ b/src/k8s/subscriptions/DEV-CSTAR/terraform.tfvars
@@ -237,6 +237,7 @@ configmaps_faenrollment = {
   POSTGRES_POOLSIZE                                 = "2"
   POSTGRES_SHOW_SQL                                 = "true"
   LOG_LEVEL_FA_ENROLLMENT                           = "DEBUG"
+  MS_AGENZIA_ENTRATE_HOST                           = "cstariobackendtest"
 }
 
 configmaps_fapaymentinstrument = {

--- a/src/k8s/subscriptions/DEV-CSTAR/terraform.tfvars
+++ b/src/k8s/subscriptions/DEV-CSTAR/terraform.tfvars
@@ -274,7 +274,7 @@ configmaps_fainvoicemanager = {
   POSTGRES_POOLSIZE                                 = "2"
   POSTGRES_SHOW_SQL                                 = "true"
   LOG_LEVEL_FA_INVOICE_MANAGER                      = "DEBUG"
-  MS_AGENZIA_ENTRATE_HOST                           = "cstariobackendtest"
+  MS_AGENZIA_ENTRATE_HOST                           = format("%s/cstariobackendtest", ingress_load_balancer_ip)
 }
 
 configmaps_fainvoiceprovider = {

--- a/src/k8s/subscriptions/DEV-CSTAR/terraform.tfvars
+++ b/src/k8s/subscriptions/DEV-CSTAR/terraform.tfvars
@@ -274,7 +274,6 @@ configmaps_fainvoicemanager = {
   POSTGRES_POOLSIZE                                 = "2"
   POSTGRES_SHOW_SQL                                 = "true"
   LOG_LEVEL_FA_INVOICE_MANAGER                      = "DEBUG"
-  MS_AGENZIA_ENTRATE_HOST                           = format("%s/cstariobackendtest", ingress_load_balancer_ip)
 }
 
 configmaps_fainvoiceprovider = {


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->
- Update value of env var to insert ingress ip for invocation of APIs between different namespaces

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->
This change is mandatory in order to invoke APIs exposed by BPD's mock from FA microservice

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [x] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [x] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
