### PR TITLE
[CEN-892] Expose T&C for FA

### DIFF
--- a/src/api/fa_tc/get_terms_and_conditions_html.xml
+++ b/src/api/fa_tc/get_terms_and_conditions_html.xml
@@ -1,0 +1,27 @@
+<!--
+    IMPORTANT:
+    - Policy elements can appear only within the <inbound>, <outbound>, <backend> section elements.
+    - To apply a policy to the incoming request (before it is forwarded to the backend service), place a corresponding policy element within the <inbound> section element.
+    - To apply a policy to the outgoing response (before it is sent back to the caller), place a corresponding policy element within the <outbound> section element.
+    - To add a policy, place the cursor at the desired insertion point and select a policy from the sidebar.
+    - To remove a policy, delete the corresponding policy statement from the policy document.
+    - Position the <base> element within a section element to inherit all policies from the corresponding section element in the enclosing scope.
+    - Remove the <base> element to prevent inheriting policies from the corresponding section element in the enclosing scope.
+    - Policies are applied in the order of their appearance, from the top down.
+    - Comments within policy elements are not supported and may disappear. Place your comments between policy elements or at a higher level scope.
+-->
+<policies>
+    <inbound>
+        <base />
+        <rewrite-uri template="/fa-tc.html" copy-unmatched-params="false" />
+    </inbound>
+    <backend>
+        <base />
+    </backend>
+    <outbound>
+        <base />
+    </outbound>
+    <on-error>
+        <base />
+    </on-error>
+</policies>

--- a/src/api/fa_tc/get_terms_and_conditions_pdf.xml
+++ b/src/api/fa_tc/get_terms_and_conditions_pdf.xml
@@ -1,0 +1,27 @@
+<!--
+    IMPORTANT:
+    - Policy elements can appear only within the <inbound>, <outbound>, <backend> section elements.
+    - To apply a policy to the incoming request (before it is forwarded to the backend service), place a corresponding policy element within the <inbound> section element.
+    - To apply a policy to the outgoing response (before it is sent back to the caller), place a corresponding policy element within the <outbound> section element.
+    - To add a policy, place the cursor at the desired insertion point and select a policy from the sidebar.
+    - To remove a policy, delete the corresponding policy statement from the policy document.
+    - Position the <base> element within a section element to inherit all policies from the corresponding section element in the enclosing scope.
+    - Remove the <base> element to prevent inheriting policies from the corresponding section element in the enclosing scope.
+    - Policies are applied in the order of their appearance, from the top down.
+    - Comments within policy elements are not supported and may disappear. Place your comments between policy elements or at a higher level scope.
+-->
+<policies>
+    <inbound>
+        <base />
+        <rewrite-uri template="/fa-tc.pdf" copy-unmatched-params="false" />
+    </inbound>
+    <backend>
+        <base />
+    </backend>
+    <outbound>
+        <base />
+    </outbound>
+    <on-error>
+        <base />
+    </on-error>
+</policies>

--- a/src/api/fa_tc/swagger.json.tpl
+++ b/src/api/fa_tc/swagger.json.tpl
@@ -1,0 +1,83 @@
+{
+    "swagger": "2.0",
+    "info": {
+        "title": "FA TC API",
+        "version": "1.0",
+        "description": "Api and Models"
+    },
+    "host": "${host}",
+    "basePath": "/fa/tc",
+    "schemes": ["https"],
+    "paths": {
+        "/html": {
+            "get": {
+                "description": "getTermsAndConditions",
+                "operationId": "getTermsAndConditionsUsingGET",
+                "summary": "getTermsAndConditionsHTML",
+                "tags": ["Fattura Automatica File Storage Controller"],
+                "produces": ["application/pdf"],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/InputStreamResource"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found"
+                    },
+                    "500": {
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/pdf": {
+            "get": {
+                "description": "getTermsAndConditions",
+                "operationId": "getTermsAndConditionsPDF",
+                "summary": "getTermsAndConditionsPDF",
+                "produces": ["application/pdf"],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/InputStreamResource"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found"
+                    },
+                    "500": {
+                        "description": ""
+                    }
+                }
+            }
+        }
+    },
+    "definitions": {
+        "InputStream": {
+            "title": "InputStream",
+            "type": "object"
+        },
+        "InputStreamResource": {
+            "title": "InputStreamResource",
+            "type": "object",
+            "properties": {
+                "description": {
+                    "type": "string"
+                },
+                "inputStream": {
+                    "$ref": "#/definitions/InputStream"
+                },
+                "read": {
+                    "type": "boolean"
+                }
+            }
+        }
+    },
+    "tags": [{
+        "name": "Fattura Automatica File Storage Controller",
+        "description": "Fa File Storage Controller Impl"
+    }]
+}

--- a/src/storage.tf
+++ b/src/storage.tf
@@ -83,6 +83,13 @@ resource "azurerm_storage_container" "bpd_terms_and_conditions" {
   container_access_type = "blob"
 }
 
+# Container terms and conditions
+resource "azurerm_storage_container" "fa_terms_and_conditions" {
+  name                  = "fa-terms-and-conditions"
+  storage_account_name  = module.cstarblobstorage.name
+  container_access_type = "blob"
+}
+
 # Container export
 resource "azurerm_storage_container" "cstar_exports" {
   name                  = "cstar-exports"


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
This proposes a way to expose FA T&C in all envronments

### List of changes

<!--- Describe your changes in detail -->
- New container `fa_terms_and_contitions` in a blob storage to host html and pdf version of T&C
- New api object on APIM to expose T&C + policies
- Refactor of FA Api Product to have it in all environments

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

This PR allows to implement the full "onboarding" user journey which encompasses user onboarding, card enrollment and acceptance of legal terms, hosted and served as a T&C file.

### Type of changes

- [x] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [x] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
