### PR TITLE
[CEN-931] Simple clone (no indexes nor columns attributes) of bpd_citizen_ranking

### DIFF
--- a/src/psql/migrations/PROD-CSTAR/bpd/V9__bpd_backup_citizen_ranking_for_supercashback.sql
+++ b/src/psql/migrations/PROD-CSTAR/bpd/V9__bpd_backup_citizen_ranking_for_supercashback.sql
@@ -1,0 +1,2 @@
+CREATE TABLE  bpd_citizen.bpd_citizen_ranking_before_supercashback_bkp SELECT * FROM bpd_citizen.bpd_citizen_ranking;
+GRANT SELECT ON TABLE bpd_citizen.bpd_citizen_ranking_before_supercashback_bkp TO "MONITORING_OPERATION_USER";

--- a/src/psql/migrations/PROD-CSTAR/bpd/V9__bpd_backup_citizen_ranking_for_supercashback.sql
+++ b/src/psql/migrations/PROD-CSTAR/bpd/V9__bpd_backup_citizen_ranking_for_supercashback.sql
@@ -1,2 +1,2 @@
-CREATE TABLE  bpd_citizen.bpd_citizen_ranking_before_supercashback_bkp SELECT * FROM bpd_citizen.bpd_citizen_ranking;
+CREATE TABLE  bpd_citizen.bpd_citizen_ranking_before_supercashback_bkp AS SELECT * FROM bpd_citizen.bpd_citizen_ranking;
 GRANT SELECT ON TABLE bpd_citizen.bpd_citizen_ranking_before_supercashback_bkp TO "MONITORING_OPERATION_USER";


### PR DESCRIPTION
This PR proposes to clone the table `bpd_citizen_ranking` as a backup for disaster recovery just in case we experience problems while computing supercashback ranking

### List of changes

<!--- Describe your changes in detail -->
- A new backup table with data and structure from `bpd_citizen_ranking`
- Grant select privileges to Operations Departement

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

This PR is a way to enable disaster recovery just in case computation of supercashback ranking would produce  irreversible errors. 

### Type of changes

- [x] Add new resources
- [ ] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
