### PR TITLE
[CEN-1002] Scale Down PROD DB

### DIFF
--- a/src/env/prod/terraform.tfvars
+++ b/src/env/prod/terraform.tfvars
@@ -217,20 +217,20 @@ cidr_subnet_eventhub  = ["10.230.6.64/26"]
 devops_service_connection_object_id = "239c15f9-6d56-4b9e-b08d-5f7779446174"
 azdo_sp_tls_cert_enabled            = false
 
-db_sku_name                     = "GP_Gen5_16"
+db_sku_name                     = "GP_Gen5_8"
 db_geo_redundant_backup_enabled = false
 db_enable_replica               = true
 db_storage_mb                   = 5242880 # 5TB
-db_configuration = {
-  autovacuum_work_mem         = "-1"
-  effective_cache_size        = "5242880"
-  log_autovacuum_min_duration = "5000"
-  log_connections             = "off"
-  log_line_prefix             = "%t [%p apps:%a host:%r]: [%l-1] db=%d,user=%u"
-  log_temp_files              = "4096"
-  maintenance_work_mem        = "524288"
-  max_wal_size                = "4096"
-}
+# db_configuration = {
+#   autovacuum_work_mem         = "-1"
+#   effective_cache_size        = "5242880"
+#   log_autovacuum_min_duration = "5000"
+#   log_connections             = "off"
+#   log_line_prefix             = "%t [%p apps:%a host:%r]: [%l-1] db=%d,user=%u"
+#   log_temp_files              = "4096"
+#   maintenance_work_mem        = "524288"
+#   max_wal_size                = "4096"
+# }
 db_replica_network_rules = {
   ip_rules = [
     "18.192.147.151/32" #PDND


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

In order to reduce costs, this PR proposes to scale down the DBMS

### List of changes

<!--- Describe your changes in detail -->
- Set DBMS SKU to `GEN 5 8 core`
- Remove Custom configs of the DBMS (set default values)


### Motivation and context

<!--- Why is this change required? What problem does it solve? -->
Due to disposal of the Cashback program, the load on the system is heavily reduced, so cost and resources should be cut down

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [x] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

The plan proposes 16 resource deletion, but this is normal since I have removed custom configuration (to set the defaults) and each conf variable counts as a resource. 

- [ ] Yes
- [X] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
