### PR TITLE
[CEN-1010] Add HPA for microservice ranking processor

### DIFF
--- a/src/k8s/subscriptions/PROD-CSTAR/terraform.tfvars
+++ b/src/k8s/subscriptions/PROD-CSTAR/terraform.tfvars
@@ -563,4 +563,27 @@ autoscaling_specs = {
       }
     ]
   }
+
+  bpdmsrankingprocessor = {
+
+    namespace = "bpd"
+
+    max_replicas = 5
+    min_replicas = 1
+
+    metrics = [
+      {
+        type = "Resource"
+        resource = {
+
+          name = "cpu"
+
+          target = {
+            type  = "Utilization"
+            average_utilization = 85
+          }
+        }
+      }
+    ]
+  }
 }


### PR DESCRIPTION
This PR enables [HPA](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/) for the bpdmsrankingprocessor deployment.

### List of changes

- HPA for deployment bpdmsrankingprocessor

### Motivation and context

This change allows us to move away from a fixed allocation of resources in order to optimize operational costs.

### Type of changes

- [x] Add new resources
- [ ] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [x] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

---

### If PR is partially applied, why? (reserved to maintainers)
