### PR TITLE
[CEN-1066] Grant PDND access on master DBMS in prod

### DIFF
--- a/src/env/prod/terraform.tfvars
+++ b/src/env/prod/terraform.tfvars
@@ -229,6 +229,15 @@ db_replica_network_rules = {
   # dblink
   allow_access_to_azure_services = true
 }
+
+db_network_rules = {
+  ip_rules = [
+    "18.192.147.151/32" #PDND
+  ]
+  # dblink
+  allow_access_to_azure_services = true
+}
+
 db_metric_alerts = {
   cpu = {
     aggregation = "Average"


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
This PR proposes to create a firewall rule on prod DBMS to grant access to PDND

### List of changes

<!--- Describe your changes in detail -->
- New firewall rule to allow access from PDND outbound address

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->
In a couple of weeks BPD will reach its end of life. In order to reduce costs, PDND should read data from master dbms, since the replicas will be deleted 


### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [x] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
