### PR TITLE
[CEN-1045] Add configmap for RTD transaction filter service

### DIFF
--- a/src/k8s/rtd_configmaps.tf
+++ b/src/k8s/rtd_configmaps.tf
@@ -19,6 +19,34 @@ resource "kubernetes_config_map" "rtdpaymentinstrumentmanager" {
   )
 }
 
+resource "kubernetes_config_map" "rtdtransactionfilter" {
+  metadata {
+    name      = "rtdtransactionfilter"
+    namespace = kubernetes_namespace.rtd.metadata[0].name
+  }
+
+  data = merge({
+    ACQ_BATCH_SCHEDULED              = "true"
+    # ACQ_BATCH_INPUT_CRON             = "" Should be set per environment
+    LOG_LEVEL_RTD_TRANSACTION_FILTER = "INFO"
+    ACQ_BATCH_TOKEN_INPUT_PATH       = "/tmp/input"
+    ACQ_BATCH_TRX_INPUT_PATH         = "/tmp/input"
+    ACQ_BATCH_TRX_LOGS_PATH          = "/tmp/logs"
+    ACQ_BATCH_OUTPUT_PATH            = "/tmp/output"
+    ACQ_BATCH_TRX_LIST_APPLY_ENCRYPT = "false"
+    ACQ_BATCH_INPUT_PUBLIC_KEYPATH   = ""
+    # HPAN_SERVICE_URL                 = "" Should be set per environment
+    ACH_BATCH_HPAN_ON_SUCCESS        = "ARCHIVE"
+    HPAN_SERVICE_KEY_STORE_FILE      = "/tmp/certs.jks"
+    HPAN_SERVICE_TRUST_STORE_FILE    = "/tmp/certs.jks"
+    ACQ_BATCH_TOKEN_PAN_VALIDATION   = "false"
+    ACQ_BATCH_HPAN_INPUT_PATH        = "/tmp/hpans"
+    ACQ_BATCH_PAR_RECOVERY_ENABLED   = "false"
+    },
+    var.configmaps_rtdtransactionfilter
+  )
+}
+
 resource "kubernetes_config_map" "rtd-eventhub-common" {
   metadata {
     name      = "eventhub-common"

--- a/src/k8s/subscriptions/DEV-CSTAR/terraform.tfvars
+++ b/src/k8s/subscriptions/DEV-CSTAR/terraform.tfvars
@@ -226,6 +226,10 @@ configmaps_rtdpaymentinstrumentmanager = {
   LOG_LEVEL_RTD_PAYMENT_INSTRUMENT_MANAGER          = "INFO"
 }
 
+configmaps_rtdtransactionfilter = {
+  HPAN_SERVICE_URL     = "https://api.uat.cstar.pagopa.it"
+  ACQ_BATCH_INPUT_CRON = "0 * * * * *"
+}
 
 configmaps_facustomer = {
   JAVA_TOOL_OPTIONS                                 = "-Xms128m -Xmx2g -javaagent:/applicationinsights-agent.jar"

--- a/src/k8s/variables.tf
+++ b/src/k8s/variables.tf
@@ -156,6 +156,10 @@ variable "configmaps_rtdpaymentinstrumentmanager" {
   type = map(string)
 }
 
+variable "configmaps_rtdtransactionfilter" {
+  type    = map(string)
+  default = {}
+}
 
 variable "configmaps_facustomer" {
   type = map(string)


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

This PR introduces a new config map defining the execution environment for the service RTD transaction filter (a.k.a. batch acquirer)

### List of changes

Added configmap definition and subscription variables for DEV environment

### Motivation and context

The configmap is needed in order to run the transaction filter service on DEV environment

### Type of changes

- [x] Add new resources
- [ ] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
