### PR TITLE
[CEN-1093] Scale Down Prod DBMS SKU to 2 V-Core

### DIFF
--- a/src/env/prod/terraform.tfvars
+++ b/src/env/prod/terraform.tfvars
@@ -217,18 +217,11 @@ cidr_subnet_eventhub  = ["10.230.6.64/26"]
 devops_service_connection_object_id = "239c15f9-6d56-4b9e-b08d-5f7779446174"
 azdo_sp_tls_cert_enabled            = false
 
-db_sku_name                     = "GP_Gen5_4"
+db_sku_name                     = "GP_Gen5_2"
 db_geo_redundant_backup_enabled = false
 db_enable_replica               = false
 db_storage_mb                   = 5242880 # 5TB
 
-# db_replica_network_rules = {
-#   ip_rules = [
-#     "18.192.147.151/32" #PDND
-#   ]
-#   # dblink
-#   allow_access_to_azure_services = true
-# }
 
 db_network_rules = {
   ip_rules = [
@@ -275,7 +268,7 @@ db_metric_alerts = {
     aggregation = "Average"
     metric_name = "active_connections"
     operator    = "GreaterThan"
-    threshold   = 196
+    threshold   = 116
     frequency   = "PT5M"
     window_size = "PT5M"
     dimension   = []
@@ -298,15 +291,6 @@ db_metric_alerts = {
     window_size = "PT15M"
     dimension   = []
   }
-  # replica_lag = {
-  #   aggregation = "Average"
-  #   metric_name = "pg_replica_log_delay_in_seconds"
-  #   operator    = "GreaterThan"
-  #   threshold   = 60
-  #   frequency   = "PT1M"
-  #   window_size = "PT5M"
-  #   dimension   = []
-  # }
 }
 dns_zone_prefix = "cstar"
 enable_azdoa    = true


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
This PR proposes to scale down the production DBMS to 2 vcore (10 GB RAM)

### List of changes

<!--- Describe your changes in detail -->
- Set the Prod DBMS SKU to `GP_Gen5_2`
- Set Alarm Threshold on active connections to 116

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->
The goal of this PR is further reduce infrastructure cost

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [x] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
