### PR TITLE
[CEN-1097] Destroy external redis cache and detach it from APIM

### DIFF
--- a/src/api.tf
+++ b/src/api.tf
@@ -30,8 +30,13 @@ module "apim" {
   publisher_email         = data.azurerm_key_vault_secret.apim_publisher_email.value
   sku_name                = var.apim_sku
   virtual_network_type    = "Internal"
-  redis_connection_string = module.redis.primary_connection_string
-  redis_cache_id          = module.redis.id
+
+  # To enable external cache uncomment the following lines
+  # redis_connection_string = module.redis.primary_connection_string
+  # redis_cache_id          = module.redis.id
+  
+  redis_connection_string = null
+  redis_cache_id          = null
 
   # This enables the Username and Password Identity Provider
   sign_up_enabled = true

--- a/src/outputs.tf
+++ b/src/outputs.tf
@@ -149,23 +149,24 @@ output "postgresql_replica_fqdn" {
   value = module.postgresql.replica_fqdn
 }
 
+# To enable outputs related to redis cache, please uncomment the following lines
 ## Redis cache
-output "redis_primary_access_key" {
-  value     = module.redis.primary_access_key
-  sensitive = true
-}
+# output "redis_primary_access_key" {
+#   value     = module.redis.primary_access_key
+#   sensitive = true
+# }
 
-output "redis_hostname" {
-  value = module.redis.hostname
-}
+# output "redis_hostname" {
+#   value = module.redis.hostname
+# }
 
-output "redis_port" {
-  value = module.redis.port
-}
+# output "redis_port" {
+#   value = module.redis.port
+# }
 
-output "redis_ssl_port" {
-  value = module.redis.ssl_port
-}
+# output "redis_ssl_port" {
+#   value = module.redis.ssl_port
+# }
 
 
 # Blob storage

--- a/src/redis_cache.tf
+++ b/src/redis_cache.tf
@@ -1,16 +1,17 @@
-module "redis" {
+# To provision a redis cache uncomment the following lines
+# module "redis" {
 
-  source = "git::https://github.com/pagopa/azurerm.git//redis_cache?ref=v1.0.37"
+#   source = "git::https://github.com/pagopa/azurerm.git//redis_cache?ref=v1.0.37"
 
-  name                  = format("%s-redis", local.project)
-  resource_group_name   = azurerm_resource_group.db_rg.name
-  location              = azurerm_resource_group.db_rg.location
-  capacity              = var.redis_capacity
-  enable_non_ssl_port   = false
-  family                = var.redis_family
-  sku_name              = var.redis_sku_name
-  enable_authentication = true
-  subnet_id             = length(module.redis_snet.*.id) == 0 ? null : module.redis_snet[0].id
+#   name                  = format("%s-redis", local.project)
+#   resource_group_name   = azurerm_resource_group.db_rg.name
+#   location              = azurerm_resource_group.db_rg.location
+#   capacity              = var.redis_capacity
+#   enable_non_ssl_port   = false
+#   family                = var.redis_family
+#   sku_name              = var.redis_sku_name
+#   enable_authentication = true
+#   subnet_id             = length(module.redis_snet.*.id) == 0 ? null : module.redis_snet[0].id
 
-  tags = var.tags
-}
+#   tags = var.tags
+# }


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
This PR proposes to destroy the Redis Cache and detach it as APIM external cache.

### List of changes

<!--- Describe your changes in detail -->
- Remove resource `module.redis`
- Set to `null` redis connection string in APIM definition

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->
Under the current load, APIM uses only 500 MB of external cache, so it could rely on its internal cache, which is as big as 5 GB

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [x] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
