### PR TITLE
[CEN-1103] Add Index on fiscal code to winning transaction transfer

### DIFF
--- a/src/psql/migrations/PROD-CSTAR/bpd/V10__optimization_delete_citizen.sql
+++ b/src/psql/migrations/PROD-CSTAR/bpd/V10__optimization_delete_citizen.sql
@@ -1,0 +1,5 @@
+--
+-- Name: bpd_winning_transaction_transfer_fiscal_code_s_idx; Type: INDEX; Schema: bpd_winning_transaction_transfer; Owner: ddsadmin
+--
+
+CREATE INDEX bpd_winning_transaction_transfer_fiscal_code_s_idx ON bpd_winning_transaction.bpd_winning_transaction_transfer USING btree (fiscal_code_s);


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
This PR proposes to add an index in table `bpd_winning_transaction_transfer` on `fiscal_code_s` column to speed up the following query executed during user cancellation

`delete from bpd_winning_transaction_transfer where fiscal_code_s=$1`

### List of changes

<!--- Describe your changes in detail -->
- New index

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->
This PR is a tentative to speed up a query which is executed for user cancellation.

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [x] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
