### PR TITLE
[CEN-1082] set JAVA_TOOL_OPTIONS on RTD transaction filter DEV

### DIFF
--- a/src/k8s/subscriptions/DEV-CSTAR/terraform.tfvars
+++ b/src/k8s/subscriptions/DEV-CSTAR/terraform.tfvars
@@ -228,6 +228,7 @@ configmaps_rtdpaymentinstrumentmanager = {
 }
 
 configmaps_rtdtransactionfilter = {
+  JAVA_TOOL_OPTIONS    = "-Xms4g -Xmx4g"
   HPAN_SERVICE_URL     = "https://api.uat.cstar.pagopa.it"
   ACQ_BATCH_INPUT_CRON = "0 * * * * *"
 }


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

This PR proposes to set the JVM allocated memory to the Batch Acquirer to 4GB, as [suggested in the documentation](https://github.com/pagopa/rtd-ms-transaction-filter/blob/1.0.2/README.md#logging-configurations), in the DEV environment.

### List of changes

<!--- Describe your changes in detail -->

Added JAVA_TOOL_OPTIONS parameter to the rtdmstransactionfilter configmap in the DEV environment

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->
This change aligns the actual DEV configuration with the suggested one from the software documentation

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
