### PR TITLE
[CEN-1084] Enabled encryption of file produced by RTD transactionfilter

### DIFF
--- a/src/k8s/rtd_configmaps.tf
+++ b/src/k8s/rtd_configmaps.tf
@@ -35,8 +35,8 @@ resource "kubernetes_config_map" "rtdtransactionfilter" {
     ACQ_BATCH_TRX_INPUT_PATH         = "/app_workdir/input"
     ACQ_BATCH_TRX_LOGS_PATH          = "/app_workdir/logs"
     ACQ_BATCH_OUTPUT_PATH            = "/app_workdir/output"
-    ACQ_BATCH_TRX_LIST_APPLY_ENCRYPT = "false"
-    ACQ_BATCH_INPUT_PUBLIC_KEYPATH   = ""
+    ACQ_BATCH_TRX_LIST_APPLY_ENCRYPT = "true"
+    ACQ_BATCH_INPUT_PUBLIC_KEYPATH   = "/app_certs_in/publickey.asc"
     # HPAN_SERVICE_URL                 = "" Should be set per environment
     ACH_BATCH_HPAN_ON_SUCCESS        = "ARCHIVE"
     HPAN_SERVICE_KEY_STORE_FILE      = "/app/certs.jks"

--- a/src/k8s/rtd_secrets.tf
+++ b/src/k8s/rtd_secrets.tf
@@ -26,6 +26,7 @@ resource "kubernetes_secret" "rtdtransactionfilter" {
     HPAN_SERVICE_KEY_STORE_PASSWORD       = module.key_vault_secrets_query.values["rtdtransactionfilter-hpan-service-key-store-password"].value
     HPAN_SERVICE_TRUST_STORE_PASSWORD     = module.key_vault_secrets_query.values["rtdtransactionfilter-hpan-service-trust-store-password"].value
     HPAN_SERVICE_JKS_CONTENT_BASE64       = module.key_vault_secrets_query.values["rtdtransactionfilter-hpan-service-jks-content-base64"].value
+    HPAN_SERVICE_ENC_PUBLIC_KEY_ARMORED   = module.key_vault_secrets_query.values["rtdtransactionfilter-hpan-service-enc-public-key-armored"].value
   }
 
   type = "Opaque"

--- a/src/k8s/subscriptions/DEV-CSTAR/terraform.tfvars
+++ b/src/k8s/subscriptions/DEV-CSTAR/terraform.tfvars
@@ -434,5 +434,6 @@ secrets_to_be_read_from_kv = [
     "rtdtransactionfilter-hpan-service-api-key",
     "rtdtransactionfilter-hpan-service-key-store-password",
     "rtdtransactionfilter-hpan-service-trust-store-password",
-    "rtdtransactionfilter-hpan-service-jks-content-base64"
+    "rtdtransactionfilter-hpan-service-jks-content-base64",
+    "rtdtransactionfilter-hpan-service-enc-public-key-armored"
   ]


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

This PR enable the encryption of output file produced by the Batch Acquirer using a PGP key.

### List of changes

<!--- Describe your changes in detail -->
- Added a secret to safely store the key
- Enabled encryption by setting ACQ_BATCH_TRX_LIST_APPLY_ENCRYPT to true and ACQ_BATCH_INPUT_PUBLIC_KEYPATH to the path where the key will be available inside the pod

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->
We need to test this capability in our DEV environment

### Type of changes

- [x] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
