### PR TITLE
[CEN-1134] Add contractId in API's input body

### DIFF
--- a/src/api/fa_mock/swagger.json.tpl
+++ b/src/api/fa_mock/swagger.json.tpl
@@ -269,6 +269,9 @@
         },
         "pos_type": {
           "type": "string"
+        },
+        "contractId": {
+          "type": "integer"
         }
       }
     }

--- a/src/api/fa_register_transaction/openapi.json.tpl
+++ b/src/api/fa_register_transaction/openapi.json.tpl
@@ -98,7 +98,8 @@
                 "merchantId",
                 "terminalId",
                 "trxDate",
-                "vatNumber"
+                "vatNumber",
+                "contractId"
             ],
             "type": "object",
             "properties": {
@@ -142,6 +143,10 @@
                 "vatNumber": {
                     "description": "partita iva associata al merchant",
                     "type": "string"
+                },
+                "contractId": {
+                     "description": "identificativo del legame tra registrante e shop",
+                     "type": "integer"
                 }
             },
             "example": {
@@ -152,7 +157,8 @@
                 "merchantId": 0,
                 "terminalId": 0,
                 "trxDate": "string",
-                "vatNumber": "string"
+                "vatNumber": "string",
+                "contractId": 0
             }
         }
     },


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->
- Add contractId in FaTransaction and Mock interfaces to link POS transaction to correct provider

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->
This change is necessary to extract correct provider during acquirer transaction's injection process and send invoice request

### Type of changes

- [x] Add new resources
- [ ] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [x] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [x] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
