### PR TITLE
[CEN-1080] Create a migration for bpd_award_winner backup

### DIFF
--- a/src/psql/migrations/PROD-CSTAR/bpd/V11__bpd_backup_award_winner_for_state_41.sql
+++ b/src/psql/migrations/PROD-CSTAR/bpd/V11__bpd_backup_award_winner_for_state_41.sql
@@ -1,0 +1,2 @@
+CREATE TABLE  bpd_citizen.bpd_award_winner_bkp_state_41 AS SELECT * FROM bpd_citizen.bpd_award_winner;
+GRANT SELECT ON TABLE bpd_citizen.bpd_award_winner_bkp_state_41 TO "MONITORING_OPERATION_USER";


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
This PR proposes to create a backup of `bpd_citizen.bpd_award_winner` table

### List of changes

<!--- Describe your changes in detail -->

- A new `V11` `flyway` migration to create the backup (only data)

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->
This PR is useful if manual update of certain wire transfers stored in `bpd_award_winner` table fails

### Type of changes

- [x] Add new resources
- [ ] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
