### PR TITLE
[CEN-1236] Align policy of api award_period to changes made via azure portal

### DIFF
--- a/src/api.tf
+++ b/src/api.tf
@@ -897,7 +897,7 @@ resource "azurerm_api_management_api_version_set" "bpd_io_award_period" {
 
 ### original ###
 module "bpd_io_award_period_original" {
-  source              = "git::https://github.com/pagopa/azurerm.git//api_management_api?ref=CEN-1235-manage-api-revision"
+  source              = "git::https://github.com/pagopa/azurerm.git//api_management_api?ref=v2.0.23"
   name                = format("%s-bpd-io-award-period-api", var.env_short)
   api_management_name = module.apim.name
   resource_group_name = azurerm_resource_group.rg_api.name
@@ -933,7 +933,7 @@ module "bpd_io_award_period_original" {
 
 ### v2 ###
 module "bpd_io_award_period_v2" {
-  source              = "git::https://github.com/pagopa/azurerm.git//api_management_api?ref=CEN-1235-manage-api-revision"
+  source              = "git::https://github.com/pagopa/azurerm.git//api_management_api?ref=v2.0.23"
   name                = format("%s-bpd-io-award-period-api", var.env_short)
   api_management_name = module.apim.name
   resource_group_name = azurerm_resource_group.rg_api.name

--- a/src/api.tf
+++ b/src/api.tf
@@ -897,11 +897,13 @@ resource "azurerm_api_management_api_version_set" "bpd_io_award_period" {
 
 ### original ###
 module "bpd_io_award_period_original" {
-  source              = "git::https://github.com/pagopa/azurerm.git//api_management_api?ref=v1.0.16"
+  source              = "git::https://github.com/pagopa/azurerm.git//api_management_api?ref=CEN-1235-manage-api-revision"
   name                = format("%s-bpd-io-award-period-api", var.env_short)
   api_management_name = module.apim.name
   resource_group_name = azurerm_resource_group.rg_api.name
   version_set_id      = azurerm_api_management_api_version_set.bpd_io_award_period.id
+  revision            = 2
+  revision_description = "closing cashback"
 
   description  = "findAll"
   display_name = "BPD IO Award Period API"
@@ -922,7 +924,7 @@ module "bpd_io_award_period_original" {
   api_operation_policies = [
     {
       operation_id = "findAllUsingGET"
-      xml_content = templatefile("./api/bpd_io_award_period/original/findAllUsingGET_policy.xml.tmpl", {
+      xml_content = templatefile("./api/bpd_io_award_period/original/findAllUsingGET_close_cashback_policy.xml.tmpl", {
         env_short = var.env_short
       })
     }
@@ -931,11 +933,13 @@ module "bpd_io_award_period_original" {
 
 ### v2 ###
 module "bpd_io_award_period_v2" {
-  source              = "git::https://github.com/pagopa/azurerm.git//api_management_api?ref=v1.0.16"
+  source              = "git::https://github.com/pagopa/azurerm.git//api_management_api?ref=CEN-1235-manage-api-revision"
   name                = format("%s-bpd-io-award-period-api", var.env_short)
   api_management_name = module.apim.name
   resource_group_name = azurerm_resource_group.rg_api.name
   version_set_id      = azurerm_api_management_api_version_set.bpd_io_award_period.id
+  revision            = 2
+  revision_description = "closing cashback"
   api_version         = "v2"
 
   description  = "findAll"
@@ -958,7 +962,7 @@ module "bpd_io_award_period_v2" {
   api_operation_policies = [
     {
       operation_id = "findAllUsingGET"
-      xml_content = templatefile("./api/bpd_io_award_period/v2/findAllUsingGET_policy.xml.tmpl", {
+      xml_content = templatefile("./api/bpd_io_award_period/v2/findAllUsingGET_close_cashback_policy.xml.tmpl", {
         env_short = var.env_short
       })
     }

--- a/src/api/bpd_io_award_period/original/findAllUsingGET_close_cashback_policy.xml.tmpl
+++ b/src/api/bpd_io_award_period/original/findAllUsingGET_close_cashback_policy.xml.tmpl
@@ -1,0 +1,38 @@
+<!--
+   IMPORTANT:
+   - Policy elements can appear only within the <inbound>, <outbound>, <backend> section elements.
+   - To apply a policy to the incoming request (before it is forwarded to the backend service), place a corresponding policy element within the <inbound> section element.
+   - To apply a policy to the outgoing response (before it is sent back to the caller), place a corresponding policy element within the <outbound> section element.
+   - To add a policy, place the cursor at the desired insertion point and select a policy from the sidebar.
+   - To remove a policy, delete the corresponding policy statement from the policy document.
+   - Position the <base> element within a section element to inherit all policies from the corresponding section element in the enclosing scope.
+   - Remove the <base> element to prevent inheriting policies from the corresponding section element in the enclosing scope.
+   - Policies are applied in the order of their appearance, from the top down.
+   - Comments within policy elements are not supported and may disappear. Place your comments between policy elements or at a higher level scope.
+-->
+<policies>
+  <inbound>
+    <base />
+    <cache-lookup-value key="awardPeriodsResponse" variable-name="awardPeriodsResponse" caching-type="internal" />
+    <choose>
+      <when condition="@(context.Variables.ContainsKey("awardPeriodsResponse"))">
+        <return-response response-variable-name="awardPeriodsResponse" />
+      </when>
+    </choose>
+  </inbound>
+  <backend>
+    <base />
+  </backend>
+  <outbound>
+    <base />
+    <choose>
+      <when condition="@(context.Response.StatusCode >= 200 &&  context.Response.StatusCode < 300)">
+        <!-- Store result in cache -->
+        <cache-store-value key="awardPeriodsResponse" value="@(context.Response)" duration="3600" caching-type="internal" />
+      </when>
+    </choose>
+  </outbound>
+  <on-error>
+    <base />
+  </on-error>
+</policies>

--- a/src/api/bpd_io_award_period/v2/findAllUsingGET_close_cashback_policy.xml.tmpl
+++ b/src/api/bpd_io_award_period/v2/findAllUsingGET_close_cashback_policy.xml.tmpl
@@ -1,0 +1,38 @@
+<!--
+   IMPORTANT:
+   - Policy elements can appear only within the <inbound>, <outbound>, <backend> section elements.
+   - To apply a policy to the incoming request (before it is forwarded to the backend service), place a corresponding policy element within the <inbound> section element.
+   - To apply a policy to the outgoing response (before it is sent back to the caller), place a corresponding policy element within the <outbound> section element.
+   - To add a policy, place the cursor at the desired insertion point and select a policy from the sidebar.
+   - To remove a policy, delete the corresponding policy statement from the policy document.
+   - Position the <base> element within a section element to inherit all policies from the corresponding section element in the enclosing scope.
+   - Remove the <base> element to prevent inheriting policies from the corresponding section element in the enclosing scope.
+   - Policies are applied in the order of their appearance, from the top down.
+   - Comments within policy elements are not supported and may disappear. Place your comments between policy elements or at a higher level scope.
+-->
+<policies>
+    <inbound>
+            <base />
+            <cache-lookup-value key="awardPeriodsResponse" variable-name="awardPeriodsResponse" caching-type="internal" />
+            <choose>
+                    <when condition="@(context.Variables.ContainsKey("awardPeriodsResponse"))">
+                            <return-response response-variable-name="awardPeriodsResponse" />
+                    </when>
+            </choose>
+    </inbound>
+    <backend>
+            <base />
+    </backend>
+    <outbound>
+            <choose>
+                    <when condition="@(context.Response.StatusCode >= 200 &&  context.Response.StatusCode < 300)">
+                            <!-- Store result in cache -->
+                            <cache-store-value key="awardPeriodsResponseV2" value="@(context.Response)" duration="3600" caching-type="internal" />
+                    </when>
+            </choose>
+            <base />
+    </outbound>
+    <on-error>
+            <base />
+    </on-error>
+</policies>


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

This PR proposes a couple of changes to align terraform code to the new revision of the award_period api policy created via azure portal

### List of changes

<!--- Describe your changes in detail -->
- update the revision of the policy of api award_period to the one created to cose the cashback
- align the policy definition in terraform code to the one created via portal

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

This PR is needed to align the revision of the policy of award_period api to the one created via azure portal to close the cashback. 

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

This PR is dependent on the following PR
https://github.com/pagopa/azurerm/pull/148

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
