### PR TITLE
[CEN-1275] Increase default node pool node size to Standard_B4ms

### DIFF
--- a/src/env/dev/terraform.tfvars
+++ b/src/env/dev/terraform.tfvars
@@ -2,6 +2,7 @@ apim_notification_sender_email = "info@pagopa.it"
 apim_publisher_name            = "PagoPA Centro Stella DEV"
 apim_sku                       = "Developer_1"
 
+aks_vm_size = "Standard_B4ms"
 aks_alerts_enabled = false
 aks_metric_alerts = {
   node_cpu = {


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
This PR updates the node size for the 'default' node pool of the DEV AKS cluster from 'Standard_DS2_v2' to 'Standard_B4ms'

### List of changes

<!--- Describe your changes in detail -->
Set value for variable 'aks_vm_size' on DEV subscription

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->
The previous node size wasn't providing enough RAM on a single node to satisfy the workload requirements.

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
