### PR TITLE
[CEN-1303] Add postgres flexible server to support FA application

### DIFF
--- a/src/.terraform.lock.hcl
+++ b/src/.terraform.lock.hcl
@@ -23,23 +23,21 @@ provider "registry.terraform.io/hashicorp/azuread" {
 }
 
 provider "registry.terraform.io/hashicorp/azurerm" {
-  version     = "2.90.0"
-  constraints = "2.90.0"
+  version     = "2.92.0"
+  constraints = "2.92.0"
   hashes = [
-    "h1:Uh/buhWgdM/EaghlbrWye0YoFIKhH6AGxw5AVgdPX30=",
-    "h1:j2SkWgabdECJo8vGy5Q/cTLF3yVaWR1kRaO/Nopb2VY=",
-    "h1:xVG6gA/U5FgStJebgKdKJP57aDfAUHL5kD1UClXHV0w=",
-    "zh:11e484585bc324e56ece3d75bd1d8371fc1d56501fb7f15542be0185eaf2c05e",
-    "zh:189f11bba0665a45405d12b66ac789de87582d23863f0599016bcc28f399a4e3",
-    "zh:1e4103ab153f16b614c98898d4f4d46c953687a35a0381e05b4a2958b27165b8",
-    "zh:1f8bb4631f8206736e1ff560b59453d9cc6d7dd0598072feaba10b6833cda1c4",
-    "zh:424acd64ee42cf3cc78919dc32b07a8dc4e7e9cc103eca37cce2f256a48f5e6d",
-    "zh:4ce7c5469e1fbed3066bb05c3c4ad8a194b76a4d01e2bbd7093537aa3eafeb0a",
-    "zh:6b4b592f1f3684a4df9fad146b4cbe125fffbadc2239f7011c0390199094676f",
-    "zh:8525bb868cd3e117fb1278e54c899a22ab6533c134779a64c224e651983fc253",
-    "zh:9873ee69ee94059af70ee544e0b27b68064dcc21e4d2912aa7186f46acca47c1",
-    "zh:af305aa28b532c78a1c51cf707a02bd1993ff1b8e7b5d656db8043c3eb484eab",
-    "zh:f96ecf6c3f208ad50af0959042e5fe1730b2bf26582430a61aac5b2a970917c7",
+    "h1:l2EJ5Hub3P/kadpXDj76dJoVacFurIC2IdyP9vwTeOU=",
+    "zh:0de2206cf0a876fe61b0693075a4dbe73f45b52dd8749f61a743e562aa56505d",
+    "zh:28aa7999b8592e6a1c51ee8e52690e594a64fe124413af01fb3e8f4f88b77b9a",
+    "zh:374c9d9a001e3b9987866b6f565232a29c6b8d7993ddc2d7813d5ea852eef306",
+    "zh:5379b9d07d7aa5cf9b3164269772341a4a45d7e9c4f0a771d6aa2fb41e504b06",
+    "zh:68ee6fbef0c29b38e313407b1b06257d9061ec3a7aa874f7a4ecfce6fdeb4c4e",
+    "zh:78abb83771921a088f72710ad0f0e3f32ac9e4745f2f05ac73a9332bb0eb02d1",
+    "zh:7a2418a62e38d65471eee0c5d930845652f44eaee6bbda3b72f565079a738ef1",
+    "zh:80beba432be278a8d5b01b3a08a2860f73c98a267222fc1ac274860c89088bdc",
+    "zh:be34006c07fd933e8d48ff2e1ab99412ebe6a75e6ef6d03c1cba69d357e38933",
+    "zh:e2361908ac5c903d4fc58476f641ce3e908e076b396328c19e59fe973ce3915c",
+    "zh:f94099fb71b7911196970a0c07b01abfa28efd7c4bd05f44f046bbe06eef5e6f",
   ]
 }
 

--- a/src/database.tf
+++ b/src/database.tf
@@ -107,8 +107,7 @@ module "postgres_flexible_server" {
 
   count = var.pgres_flex_params.enabled ? 1 : 0
 
-  source = "git::https://github.com/pagopa/azurerm.git//postgres_flexible_server?ref=CEN-1302-postgres-flexible-server-module"
-
+  source = "git::https://github.com/pagopa/azurerm.git//postgres_flexible_server?ref=v2.1.14"
   name                = format("%s-flexible-postgresql", local.project)
   location            = azurerm_resource_group.db_rg.location
   resource_group_name = azurerm_resource_group.db_rg.name
@@ -136,6 +135,6 @@ module "postgres_flexible_server" {
 
   tags = var.tags
 
-  depends_on = [azurerm_private_dns_zone_virtual_network_link.postgres]
+  depends_on = [azurerm_private_dns_zone_virtual_network_link.postgres_vnet]
 
 }

--- a/src/database.tf
+++ b/src/database.tf
@@ -107,7 +107,7 @@ module "postgres_flexible_server" {
 
   count = var.pgres_flex_params.enabled ? 1 : 0
 
-  source = "git::https://github.com/pagopa/azurerm.git//postgres_flexible_server?ref=v2.1.14"
+  source              = "git::https://github.com/pagopa/azurerm.git//postgres_flexible_server?ref=v2.1.14"
   name                = format("%s-flexible-postgresql", local.project)
   location            = azurerm_resource_group.db_rg.location
   resource_group_name = azurerm_resource_group.db_rg.name

--- a/src/database.tf
+++ b/src/database.tf
@@ -105,7 +105,7 @@ module "postgresql" {
 
 module "postgres_flexible_server" {
 
-  count = contains(["d"], var.env_short) ? 1 : 0
+  count = var.pgres_flex_params.enabled ? 1 : 0
 
   source = "git::https://github.com/pagopa/azurerm.git//postgres_flexible_server?ref=CEN-1302-postgres-flexible-server-module"
 

--- a/src/dns_private.tf
+++ b/src/dns_private.tf
@@ -42,3 +42,17 @@ resource "azurerm_private_dns_a_record" "private_dns_a_record_management" {
   ttl                 = 300
   records             = module.apim.*.private_ip_addresses[0]
 }
+
+# Private DNS Zone for Postgres Databases
+
+resource "azurerm_private_dns_zone" "postgres" {
+  name                = "private.postgres.database.azure.com"
+  resource_group_name = azurerm_resource_group.rg_vnet.name
+}
+
+resource "azurerm_private_dns_zone_virtual_network_link" "postgres" {
+  name                  = format("%s-postgres-private-dns-zone-link", local.project)
+  resource_group_name   = azurerm_resource_group.rg_vnet.name
+  private_dns_zone_name = azurerm_private_dns_zone.postgres.name
+  virtual_network_id    = module.vnet.id
+}

--- a/src/dns_private.tf
+++ b/src/dns_private.tf
@@ -50,8 +50,8 @@ resource "azurerm_private_dns_zone" "postgres" {
   resource_group_name = azurerm_resource_group.rg_vnet.name
 }
 
-resource "azurerm_private_dns_zone_virtual_network_link" "postgres" {
-  name                  = format("%s-postgres-private-dns-zone-link", local.project)
+resource "azurerm_private_dns_zone_virtual_network_link" "postgres_vnet" {
+  name                  = format("%s-postgres-vnet-private-dns-zone-link", local.project)
   resource_group_name   = azurerm_resource_group.rg_vnet.name
   private_dns_zone_name = azurerm_private_dns_zone.postgres.name
   virtual_network_id    = module.vnet.id

--- a/src/env/dev/terraform.tfvars
+++ b/src/env/dev/terraform.tfvars
@@ -207,6 +207,8 @@ cidr_subnet_jumpbox      = ["10.1.131.0/24"]
 cidr_subnet_redis        = ["10.1.132.0/24"]
 cidr_subnet_vpn          = ["10.1.133.0/24"]
 cidr_subnet_dnsforwarder = ["10.1.134.0/29"]
+cidr_subnet_flex_dbms    = ["10.1.136.0/24"]
+
 
 # integration vnet
 # https://www.davidc.net/sites/default/subnets/subnets.html?network=10.230.7.0&mask=24&division=7.31
@@ -300,6 +302,21 @@ db_metric_alerts = {
     dimension   = []
   }
 }
+
+pgres_flex_params = {
+  
+    sku_name                     = "B_Standard_B1ms"
+    db_version                   = "13"
+    # Possible values are 32768, 65536, 131072, 262144, 524288, 1048576, 
+    # 2097152, 4194304, 8388608, 16777216, and 33554432.
+    storage_mb                   = 32768
+    zone                         = 1
+    backup_retention_days        = 7
+    geo_redundant_backup_enabled = false
+    create_mode                  = "Default"
+  
+}
+
 
 dns_zone_prefix = "dev.cstar"
 

--- a/src/env/dev/terraform.tfvars
+++ b/src/env/dev/terraform.tfvars
@@ -304,17 +304,18 @@ db_metric_alerts = {
 }
 
 pgres_flex_params = {
-  
-    sku_name                     = "B_Standard_B1ms"
-    db_version                   = "13"
-    # Possible values are 32768, 65536, 131072, 262144, 524288, 1048576, 
-    # 2097152, 4194304, 8388608, 16777216, and 33554432.
-    storage_mb                   = 32768
-    zone                         = 1
-    backup_retention_days        = 7
-    geo_redundant_backup_enabled = false
-    create_mode                  = "Default"
-  
+
+  enabled    = true
+  sku_name   = "B_Standard_B1ms"
+  db_version = "13"
+  # Possible values are 32768, 65536, 131072, 262144, 524288, 1048576, 
+  # 2097152, 4194304, 8388608, 16777216, and 33554432.
+  storage_mb                   = 32768
+  zone                         = 1
+  backup_retention_days        = 7
+  geo_redundant_backup_enabled = false
+  create_mode                  = "Default"
+
 }
 
 

--- a/src/env/prod/terraform.tfvars
+++ b/src/env/prod/terraform.tfvars
@@ -207,6 +207,7 @@ cidr_subnet_jumpbox      = ["10.1.131.0/24"]
 cidr_subnet_redis        = ["10.1.132.0/24"]
 cidr_subnet_vpn          = ["10.1.133.0/24"]
 cidr_subnet_dnsforwarder = ["10.1.134.0/29"]
+cidr_subnet_flex_dbms    = ["10.1.136.0/24"]
 
 # integration vnet
 # https://www.davidc.net/sites/default/subnets/subnets.html?network=10.230.7.0&mask=24&division=7.31

--- a/src/env/prod/terraform.tfvars
+++ b/src/env/prod/terraform.tfvars
@@ -293,6 +293,23 @@ db_metric_alerts = {
     dimension   = []
   }
 }
+
+pgres_flex_params = {
+
+  enabled    = false
+  sku_name   = "B_Standard_B1ms"
+  db_version = "13"
+  # Possible values are 32768, 65536, 131072, 262144, 524288, 1048576, 
+  # 2097152, 4194304, 8388608, 16777216, and 33554432.
+  storage_mb                   = 32768
+  zone                         = 1
+  backup_retention_days        = 7
+  geo_redundant_backup_enabled = false
+  create_mode                  = "Default"
+
+}
+
+
 dns_zone_prefix = "cstar"
 enable_azdoa    = true
 env_short       = "p"

--- a/src/env/uat/terraform.tfvars
+++ b/src/env/uat/terraform.tfvars
@@ -302,6 +302,21 @@ db_metric_alerts = {
   }
 }
 
+pgres_flex_params = {
+
+  enabled    = false
+  sku_name   = "B_Standard_B1ms"
+  db_version = "13"
+  # Possible values are 32768, 65536, 131072, 262144, 524288, 1048576, 
+  # 2097152, 4194304, 8388608, 16777216, and 33554432.
+  storage_mb                   = 32768
+  zone                         = 1
+  backup_retention_days        = 7
+  geo_redundant_backup_enabled = false
+  create_mode                  = "Default"
+
+}
+
 dns_zone_prefix         = "uat.cstar"
 internal_private_domain = "internal.uat.cstar.pagopa.it"
 ehns_sku_name           = "Standard"

--- a/src/env/uat/terraform.tfvars
+++ b/src/env/uat/terraform.tfvars
@@ -208,6 +208,7 @@ cidr_subnet_azdoa        = ["10.1.130.0/24"]
 cidr_subnet_jumpbox      = ["10.1.131.0/24"]
 cidr_subnet_vpn          = ["10.1.132.0/24"]
 cidr_subnet_dnsforwarder = ["10.1.133.0/29"]
+cidr_subnet_flex_dbms    = ["10.1.136.0/24"]
 
 # integration vnet
 # https://www.davidc.net/sites/default/subnets/subnets.html?network=10.230.7.0&mask=24&division=7.31

--- a/src/main.tf
+++ b/src/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "= 2.90.0"
+      version = "= 2.92.0"
     }
     azuread = {
       source  = "hashicorp/azuread"

--- a/src/network.tf
+++ b/src/network.tf
@@ -604,3 +604,24 @@ resource "azurerm_network_profile" "dns_forwarder" {
     }
   }
 }
+
+# Postgres Flexible Server subnet 
+module "postgres_flexible_snet" {
+  source                                         = "git::https://github.com/pagopa/azurerm.git//subnet?ref=v2.1.13"
+  name                                           = format("%s-pgres-flexible-snet", local.project)
+  address_prefixes                               = var.cidr_subnet_flex_dbms
+  resource_group_name                            = azurerm_resource_group.rg_vnet.name
+  virtual_network_name                           = module.vnet.name
+  service_endpoints                              = ["Microsoft.Storage"]
+  enforce_private_link_endpoint_network_policies = true
+
+  delegation = {
+    name = "delegation"
+    service_delegation = {
+      name = "Microsoft.DBforPostgreSQL/flexibleServers"
+      actions = [
+        "Microsoft.Network/virtualNetworks/subnets/join/action",
+      ]
+    }
+  }
+}

--- a/src/outputs.tf
+++ b/src/outputs.tf
@@ -135,6 +135,16 @@ output "postgresql_replica_fqdn" {
   value = module.postgresql.replica_fqdn
 }
 
+# Postgres flexible server
+
+output "pgres_flex_fqdn" {
+  value = module.postgres_flexible_server.*.fqdn
+}
+
+output "pgres_flex_public_access_enabled" {
+  value = module.postgres_flexible_server.*.public_access_enabled
+}
+
 # To enable outputs related to redis cache, please uncomment the following lines
 ## Redis cache
 # output "redis_primary_access_key" {

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -23,6 +23,11 @@ variable "cidr_subnet_db" {
   description = "Database network address space."
 }
 
+variable "cidr_subnet_flex_dbms" {
+  type        = list(string)
+  description = "Postgres Flexible Server network address space."
+}
+
 variable "cidr_subnet_redis" {
   type        = list(string)
   description = "Redis network address space."
@@ -440,6 +445,20 @@ EOD
       }
     ))
   }))
+}
+
+# Postgres Flexible
+variable "pgres_flex_params" {
+  type = object({
+    sku_name                     = string
+    db_version                   = string
+    storage_mb                   = string
+    zone                         = number
+    backup_retention_days        = number
+    geo_redundant_backup_enabled = bool
+    create_mode                  = string
+  })
+
 }
 
 ## Event hub

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -450,6 +450,7 @@ EOD
 # Postgres Flexible
 variable "pgres_flex_params" {
   type = object({
+    enabled                      = bool
     sku_name                     = string
     db_version                   = string
     storage_mb                   = string


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

This PR proposes to add a new DBMS (Postgres Flexible Server) to support FA application

### List of changes

<!--- Describe your changes in detail -->

- new Postgres Flexible Server
- new private DNS zone
- new delegated subnet dedicated to the new Postgres Flexible Server
- update the azurerm provider to version 2.92.0 (required to support geo-redundancy)

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

This change is required to get many advanced feature of postgres, like high availability, a better lifetime support and a centralized connection pooling

### Type of changes

- [x] Add new resources
- [ ] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
