### PR TITLE
[CEN-1311] Add secrets to call ADE "verify vat number" API

### DIFF
--- a/src/k8s/fa_configmaps.tf
+++ b/src/k8s/fa_configmaps.tf
@@ -136,7 +136,8 @@ resource "kubernetes_config_map" "famsinvoicemanager" {
 
   data = merge({
     TZ                      = "Europe/Rome"
-    MS_AGENZIA_ENTRATE_HOST = (var.env_short == "d" ? format("%s/cstariobackendtest", var.ingress_load_balancer_ip) : "")
+    MS_AGENZIA_ENTRATE_HOST = "https://api.agenziaentrate.gov.it/entrate/api/partita-iva/v0"
+    MS_AGENZIA_ENTRATE_URL  = "https://api.agenziaentrate.gov.it/entrate/api"
     MS_AGENZIA_ENTRATE_PORT = ""
   }, var.configmaps_fainvoicemanager)
 

--- a/src/k8s/fa_secrets.tf
+++ b/src/k8s/fa_secrets.tf
@@ -172,3 +172,18 @@ resource "kubernetes_secret" "famsnotificationmanager" {
 
   type = "Opaque"
 }
+
+resource "kubernetes_secret" "famsinvoicemanager" {
+  metadata {
+    name      = "famsinvoicemanager"
+    namespace = kubernetes_namespace.fa.metadata[0].name
+  }
+
+  data = {
+    ADE_API_CLIENT_ID                     = module.key_vault_secrets_query.values["tae-ade-api-client-id"].value
+    ADE_API_CLIENT_SECRET                 = module.key_vault_secrets_query.values["tae-ade-api-client-secret"].value
+    APPLICATIONINSIGHTS_CONNECTION_STRING = local.appinsights_instrumentation_key
+  }
+
+  type = "Opaque"
+}

--- a/src/k8s/subscriptions/DEV-CSTAR/terraform.tfvars
+++ b/src/k8s/subscriptions/DEV-CSTAR/terraform.tfvars
@@ -438,5 +438,7 @@ secrets_to_be_read_from_kv = [
   "rtdtransactionfilter-hpan-service-key-store-password",
   "rtdtransactionfilter-hpan-service-trust-store-password",
   "rtdtransactionfilter-hpan-service-jks-content-base64",
-  "rtdtransactionfilter-hpan-service-enc-public-key-armored"
+  "rtdtransactionfilter-hpan-service-enc-public-key-armored",
+  "tae-ade-api-client-id",
+  "tae-ade-api-client-secret"
 ]

--- a/src/k8s/subscriptions/PROD-CSTAR/terraform.tfvars
+++ b/src/k8s/subscriptions/PROD-CSTAR/terraform.tfvars
@@ -632,5 +632,7 @@ secrets_to_be_read_from_kv = [
   "evh-fa-trx-customer-fa-trx-customer-producer-key-fa-01",
   "evh-rtd-trx-rtd-trx-producer-key",
   "evh-fa-trx-payment-instrument-fa-trx-payment-instrument-consumer-key-fa-01",
-  "evh-fa-trx-payment-instrument-fa-trx-payment-instrument-producer-key-fa-01"
+  "evh-fa-trx-payment-instrument-fa-trx-payment-instrument-producer-key-fa-01",
+  "tae-ade-api-client-id",
+  "tae-ade-api-client-secret"
 ]

--- a/src/k8s/subscriptions/UAT-CSTAR/terraform.tfvars
+++ b/src/k8s/subscriptions/UAT-CSTAR/terraform.tfvars
@@ -465,5 +465,7 @@ secrets_to_be_read_from_kv = [
   "evh-fa-trx-customer-fa-trx-customer-producer-key-fa-01",
   "evh-rtd-trx-rtd-trx-producer-key",
   "evh-fa-trx-payment-instrument-fa-trx-payment-instrument-consumer-key-fa-01",
-  "evh-fa-trx-payment-instrument-fa-trx-payment-instrument-producer-key-fa-01"
+  "evh-fa-trx-payment-instrument-fa-trx-payment-instrument-producer-key-fa-01",
+  "tae-ade-api-client-id",
+  "tae-ade-api-client-secret"
 ]


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
This PR proposes a way to add credentials to call ADE api to verify a vat number in `fa-ms-invoice-manager` micro-service environment

### List of changes

<!--- Describe your changes in detail -->
- Update the list of secrets to be read form key vault
- Create a new k8s secret
- Update fa-ms-invoice-manager environment

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->
This PR is required to be able to verify the correctness/existence of a vat number using ADE api.

### Type of changes

- [x] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
