### PR TITLE
[CEN-1314] add optInStatus in citizen API

### DIFF
--- a/src/api/bpd_io_citizen/v2/findUsingGET_policy.xml
+++ b/src/api/bpd_io_citizen/v2/findUsingGET_policy.xml
@@ -14,6 +14,15 @@
     <inbound>
         <base />
         <set-variable name="v_GetCitizenKey" value="@((string)context.Variables["fiscalCode"])" />
+
+        <return-response>
+            <set-status code="200" reason="OK" />
+            <set-header name="Content-Type" exists-action="override">
+                <value>application/json</value>
+            </set-header>
+            <set-body>{ "enabled": true, "fiscalCode": (string)context.Variables["fiscalCode"], "timestampTC": "2020-12-09T10:00:00Z", "optInStatus": 0 }</set-body>
+        </return-response>
+
         <cache-lookup-value key="@((string)context.Variables["v_GetCitizenKey"] + "-getcitizen")" variable-name="getCitizenResponse"  />
         <choose>
             <!-- If API Management find it in the cache, make a request for it and store it -->

--- a/src/api/bpd_io_citizen/v2/findUsingGET_policy.xml
+++ b/src/api/bpd_io_citizen/v2/findUsingGET_policy.xml
@@ -14,15 +14,6 @@
     <inbound>
         <base />
         <set-variable name="v_GetCitizenKey" value="@((string)context.Variables["fiscalCode"])" />
-
-        <return-response>
-            <set-status code="200" reason="OK" />
-            <set-header name="Content-Type" exists-action="override">
-                <value>application/json</value>
-            </set-header>
-            <set-body>{ "enabled": true, "fiscalCode": (string)context.Variables["fiscalCode"], "timestampTC": "2020-12-09T10:00:00Z", "optInStatus": 0 }</set-body>
-        </return-response>
-
         <cache-lookup-value key="@((string)context.Variables["v_GetCitizenKey"] + "-getcitizen")" variable-name="getCitizenResponse"  />
         <choose>
             <!-- If API Management find it in the cache, make a request for it and store it -->

--- a/src/api/bpd_io_citizen/v2/openapi.json.tpl
+++ b/src/api/bpd_io_citizen/v2/openapi.json.tpl
@@ -44,7 +44,8 @@
                                     "fiscalCode": "string",
                                     "payoffInstr": "string",
                                     "payoffInstrType": "string",
-                                    "timestampTC": "string"
+                                    "timestampTC": "string",
+                                    "optInStatus": "DENIED"
                                 }
                             }
                         }
@@ -196,7 +197,7 @@
                                     "payoffInstr": "string",
                                     "payoffInstrType": "string",
                                     "timestampTC": "string",
-                                    "optInStatus": 0
+                                    "optInStatus": "DENIED"
                                 }
                             }
                         }
@@ -352,9 +353,9 @@
                 "type": "object",
                 "properties": {
                     "optInStatus": {
-                       "enum": [0,1,2],
-                       "type": "integer",
-                       "description": "stato della richiesta utente di Opt-In per il mantenimento delle carte in AppIO (0, default, non richiesto)"
+                       "enum": ["NOREQ","ACCEPTED","DENIED"],
+                       "type": "string",
+                       "description": "stato della richiesta utente di Opt-In per il mantenimento delle carte in AppIO"
                     }
                 }
             },
@@ -503,9 +504,9 @@
                         "description": "Identificativo univoco dello strumento di pagamento rilasciato dall'issuer"
                     },
                     "optInStatus": {
-                        "enum": [0,1,2],
-                        "type": "integer",
-                        "description": "stato della richiesta utente di Opt-In per il mantenimento delle carte in AppIO (0, default, non richiesto)"
+                        "enum": ["NOREQ","ACCEPTED","DENIED"],
+                        "type": "string",
+                        "description": "stato della richiesta utente di Opt-In per il mantenimento delle carte in AppIO"
                     }
                 },
                 "example": {
@@ -514,7 +515,7 @@
                     "payoffInstr": "string",
                     "payoffInstrType": "string",
                     "timestampTC": "string",
-                    "optInStatus": 0
+                    "optInStatus": "DENIED"
                 }
             },
             "CitizenRankingMilestoneResourceArray": {

--- a/src/api/bpd_io_citizen/v2/openapi.json.tpl
+++ b/src/api/bpd_io_citizen/v2/openapi.json.tpl
@@ -174,15 +174,21 @@
                     "schema": {
                         "type": "string"
                     }
-                },
-                {
-                    "name": "CitizenDTO",
-                    "in": "body",
-                    "description": "Citizen's onboarding body",
-                    "schema": {
-                        "$ref": "#/components/schemas/CitizenDTO"
-                    }
                 }],
+                "requestBody": {
+                    "description": "Citizen",
+                    "required": false,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/CitizenPutDTO"
+                            },
+                            "example": {
+                                "optInStatus": "DENIED"
+                            }
+                        }
+                    }
+                },
                 "responses": {
                     "200": {
                         "description": "OK",
@@ -348,8 +354,8 @@
     },
     "components": {
         "schemas": {
-            "CitizenDTO": {
-                "title": "CitizenDTO",
+            "CitizenPutDTO": {
+                "title": "CitizenPutDTO",
                 "type": "object",
                 "properties": {
                     "optInStatus": {

--- a/src/api/bpd_io_citizen/v2/openapi.json.tpl
+++ b/src/api/bpd_io_citizen/v2/openapi.json.tpl
@@ -173,6 +173,14 @@
                     "schema": {
                         "type": "string"
                     }
+                },
+                {
+                    "name": "CitizenDTO",
+                    "in": "body",
+                    "description": "Citizen's onboarding body",
+                    "schema": {
+                        "$ref": "#/components/schemas/CitizenDTO"
+                    }
                 }],
                 "responses": {
                     "200": {
@@ -187,7 +195,8 @@
                                     "fiscalCode": "string",
                                     "payoffInstr": "string",
                                     "payoffInstrType": "string",
-                                    "timestampTC": "string"
+                                    "timestampTC": "string",
+                                    "optInStatus": 0
                                 }
                             }
                         }
@@ -340,13 +349,12 @@
         "schemas": {
             "CitizenDTO": {
                 "title": "CitizenDTO",
-                "required": ["timestampTC"],
                 "type": "object",
                 "properties": {
-                    "timestampTC": {
-                        "type": "string",
-                        "description": "timestamp dell'accettazione di T&C. FORMATO  ISO8601 yyyy-MM-ddTHH:mm:ss.SSSXXXXX",
-                        "format": "date-time"
+                    "optInStatus": {
+                       "enum": [0,1,2],
+                       "type": "integer",
+                       "description": "stato della richiesta utente di Opt-In per il mantenimento delle carte in AppIO (0, default, non richiesto)"
                     }
                 }
             },
@@ -493,6 +501,11 @@
                     "issuerCardId": {
                         "type": "string",
                         "description": "Identificativo univoco dello strumento di pagamento rilasciato dall'issuer"
+                    },
+                    "optInStatus": {
+                        "enum": [0,1,2],
+                        "type": "integer",
+                        "description": "stato della richiesta utente di Opt-In per il mantenimento delle carte in AppIO (0, default, non richiesto)"
                     }
                 },
                 "example": {
@@ -500,7 +513,8 @@
                     "fiscalCode": "string",
                     "payoffInstr": "string",
                     "payoffInstrType": "string",
-                    "timestampTC": "string"
+                    "timestampTC": "string",
+                    "optInStatus": 0
                 }
             },
             "CitizenRankingMilestoneResourceArray": {


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->
- Add optInStatus in request body of PUT citizen endpoint
- Add optInStatus in response body of GET citizen endpoint
- Mock response in GET citizen with default optInStatus value

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->
Those changes are required to handle new property optInStatus in Citizen API

### Type of changes

- [x] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [x] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [x] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
