### PR TITLE
[CEN-1315] add optInStatus in citizen table UAT

### DIFF
--- a/src/psql/migrations/UAT-CSTAR/bpd/U22__bpd.alter_citizen_drop_opt_in_status.sql
+++ b/src/psql/migrations/UAT-CSTAR/bpd/U22__bpd.alter_citizen_drop_opt_in_status.sql
@@ -1,0 +1,1 @@
+ALTER TABLE bpd_citizen.bpd_citizen DROP COLUMN opt_in_status_s;

--- a/src/psql/migrations/UAT-CSTAR/bpd/V22__bpd.alter_citizen_add_opt_in_status.sql
+++ b/src/psql/migrations/UAT-CSTAR/bpd/V22__bpd.alter_citizen_add_opt_in_status.sql
@@ -1,1 +1,2 @@
-ALTER TABLE bpd_citizen.bpd_citizen ADD COLUMN opt_in_status_n numeric DEFAULT 0;
+ALTER TABLE bpd_citizen.bpd_citizen ADD COLUMN opt_in_status_s VARCHAR(10);
+ALTER TABLE bpd_citizen.bpd_citizen ALTER COLUMN opt_in_status_s SET DEFAULT 'NOREQ';

--- a/src/psql/migrations/UAT-CSTAR/bpd/V22__bpd.alter_citizen_add_opt_in_status.sql
+++ b/src/psql/migrations/UAT-CSTAR/bpd/V22__bpd.alter_citizen_add_opt_in_status.sql
@@ -1,0 +1,1 @@
+ALTER TABLE bpd_citizen.bpd_citizen ADD COLUMN opt_in_status_n numeric DEFAULT 0;


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->
- Add opt_in_status_n in BPD_CITIZEN table

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->
This change is required to add new column in BPD_CITIZEN table

### Type of changes

- [x] Add new resources
- [ ] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [x] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [x] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
