### PR TITLE
[CEN-1252] Modify Postgres connection string to flexible server

### DIFF
--- a/src/k8s/fa_secrets.tf
+++ b/src/k8s/fa_secrets.tf
@@ -20,7 +20,7 @@ resource "kubernetes_secret" "fa-postgres-credentials" {
     #principal database password
     POSTGRES_PASSWORD = module.key_vault_secrets_query.values["db-fa-user-password"].value
     #principal database username
-    POSTGRES_USERNAME = format("%s@%s", module.key_vault_secrets_query.values["db-fa-login"].value, local.postgres_hostname)
+    POSTGRES_USERNAME = format("%s@%s", module.key_vault_secrets_query.values["db-fa-login"].value, local.postgres_flex_hostname)
     }
 
   type = "Opaque"

--- a/src/k8s/fa_secrets.tf
+++ b/src/k8s/fa_secrets.tf
@@ -21,7 +21,7 @@ resource "kubernetes_secret" "fa-postgres-credentials" {
     POSTGRES_PASSWORD = module.key_vault_secrets_query.values["db-fa-user-password"].value
     #principal database username
     POSTGRES_USERNAME = format("%s@%s", module.key_vault_secrets_query.values["db-fa-login"].value, local.postgres_flex_hostname)
-    }
+  }
 
   type = "Opaque"
 }

--- a/src/k8s/fa_secrets.tf
+++ b/src/k8s/fa_secrets.tf
@@ -21,15 +21,7 @@ resource "kubernetes_secret" "fa-postgres-credentials" {
     POSTGRES_PASSWORD = module.key_vault_secrets_query.values["db-fa-user-password"].value
     #principal database username
     POSTGRES_USERNAME = format("%s@%s", module.key_vault_secrets_query.values["db-fa-login"].value, local.postgres_hostname)
-    #replica database name
-    POSTGRES_REPLICA_DB_NAME = "fa"
-    #replica database hostname or ip
-    POSTGRES_REPLICA_HOST = local.postgres_replica_hostname
-    #replica database password
-    POSTGRES_REPLICA_PASSWORD = module.key_vault_secrets_query.values["db-fa-user-password"].value
-    #replica database username
-    POSTGRES_REPLICA_USERNAME = format("%s@%s", module.key_vault_secrets_query.values["db-fa-login"].value, var.env_short == "p" ? local.postgres_replica_hostname : local.postgres_hostname)
-  }
+    }
 
   type = "Opaque"
 }

--- a/src/k8s/locals.tf
+++ b/src/k8s/locals.tf
@@ -7,6 +7,7 @@ locals {
   key_vault_id                    = "${data.azurerm_subscription.current.id}/resourceGroups/${local.key_vault_resource_group}/providers/Microsoft.KeyVault/vaults/${local.key_vault_name}"
   storage_account_name            = replace(format("%s-blobstorage", local.project), "-", "")
   postgres_hostname               = "${format("%s-postgresql", local.project)}.postgres.database.azure.com"
+  postgres_flex_hostname          = "${format("%s-flexible-postgresql", local.project)}.postgres.database.azure.com"
   postgres_replica_hostname       = var.enable_postgres_replica ? "${format("%s-postgresql-rep", local.project)}.postgres.database.azure.com" : local.postgres_hostname
   appinsights_instrumentation_key = format("InstrumentationKey=%s", module.key_vault_secrets_query.values["appinsights-instrumentation-key"].value)
 }


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

This PR proposes to modify the connection string to `fa` database, now hosted on Postgres Flexible Server

### List of changes

<!--- Describe your changes in detail -->
- New terraform local variable which contains the DBMS private endpoint hostname
- Fix the k8s secret which contains the connection string

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->
This PR is required to migrate FA to a Flexible Server DBMS

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
