### PR TITLE
[CEN-1321] Modify configmaps, secrets and migration to support mock microservice

### DIFF
--- a/src/k8s/fa_configmaps.tf
+++ b/src/k8s/fa_configmaps.tf
@@ -1,3 +1,27 @@
+resource "kubernetes_config_map" "cstariobackendtest" {
+  metadata {
+    name      = "cstariobackendtest"
+    namespace = kubernetes_namespace.fa.metadata[0].name
+  }
+
+  data = merge({
+    BACKEND_IO_LOG_LEVEL                = "INFO"
+    BACKEND_IO_SERVER_ACCESSLOG_ENABLED = "true"
+    BACKEND_IO_SERVER_ACCESSLOG_PATTERN = "%%{yyyy/MM/dd HH:mm:ss.SSS}t %T %D %F %I %m %U %q"
+    BACKEND_IO_SERVER_PROCESSOR_CACHE   = "300"
+    BACKEND_IO_SERVER_THREAD_MAX        = "500"
+    JAVA_TOOL_OPTIONS                   = "-Xmx1g"
+    KAFKA_SECURITY_PROTOCOL             = "SASL_SSL"
+    KAFKA_SASL_MECHANISM                = "PLAIN"
+    KAFKA_MOCKPOCTRX_TOPIC              = "rtd-trx"
+    KAFKA_MOCKPOCTRX_GROUP_ID           = "fa-mock-poc"
+    KAFKA_SERVERS                       = local.event_hub_connection // points to bpd EH namespace
+    FA_TRANSACTION_HOST                 = format("%s/famstransaction", var.ingress_load_balancer_ip)
+    },
+    var.configmaps_cstariobackendtest
+  )
+}
+
 resource "kubernetes_config_map" "fa-eventhub-common" {
   metadata {
     name      = "eventhub-common"

--- a/src/k8s/fa_configmaps.tf
+++ b/src/k8s/fa_configmaps.tf
@@ -1,4 +1,4 @@
-resource "kubernetes_config_map" "cstariobackendtest" {
+resource "kubernetes_config_map" "facstariobackendtest" {
   metadata {
     name      = "cstariobackendtest"
     namespace = kubernetes_namespace.fa.metadata[0].name

--- a/src/k8s/fa_secrets.tf
+++ b/src/k8s/fa_secrets.tf
@@ -6,6 +6,23 @@ locals {
   jaas_config_template_fa = "org.apache.kafka.common.security.plain.PlainLoginModule required username=\"$ConnectionString\" password=\"Endpoint=sb://${format("%s-evh-ns-fa-01", local.project)}.servicebus.windows.net/;EntityPath=%s;SharedAccessKeyName=%s;SharedAccessKey=%s\";"
 }
 
+resource "kubernetes_secret" "cstariobackendtest" {
+  count = var.env_short == "d" ? 1 : 0 # only in dev
+  metadata {
+    name      = "cstariobackendtest"
+    namespace = kubernetes_namespace.fa.metadata[0].name
+  }
+
+  data = {
+    #Kafka Connection String Producer
+    KAFKA_MOCKPOCTRX_SASL_JAAS_CONFIG = format(local.jaas_config_template, "rtd-trx", "rtd-trx-producer", module.key_vault_secrets_query.values["evh-rtd-trx-rtd-trx-producer-key"].value)
+
+    APPLICATIONINSIGHTS_CONNECTION_STRING = local.appinsights_instrumentation_key
+  }
+
+  type = "Opaque"
+}
+
 resource "kubernetes_secret" "fa-postgres-credentials" {
   metadata {
     name      = "postgres-credentials"

--- a/src/k8s/fa_secrets.tf
+++ b/src/k8s/fa_secrets.tf
@@ -6,8 +6,8 @@ locals {
   jaas_config_template_fa = "org.apache.kafka.common.security.plain.PlainLoginModule required username=\"$ConnectionString\" password=\"Endpoint=sb://${format("%s-evh-ns-fa-01", local.project)}.servicebus.windows.net/;EntityPath=%s;SharedAccessKeyName=%s;SharedAccessKey=%s\";"
 }
 
-resource "kubernetes_secret" "cstariobackendtest" {
-  count = var.env_short == "d" ? 1 : 0 # only in dev
+resource "kubernetes_secret" "facstariobackendtest" {
+
   metadata {
     name      = "cstariobackendtest"
     namespace = kubernetes_namespace.fa.metadata[0].name

--- a/src/psql/migrations/DEV-CSTAR/fa/U1__fa_drop_schemas_and_tables.sql
+++ b/src/psql/migrations/DEV-CSTAR/fa/U1__fa_drop_schemas_and_tables.sql
@@ -1,8 +1,9 @@
 
-DROP SCHEMA fa_customer CASCADE;
-DROP SCHEMA fa_merchant CASCADE;
-DROP SCHEMA fa_payment_instrument CASCADE;
-DROP SCHEMA fa_provider CASCADE;
-DROP SCHEMA fa_transaction CASCADE;
-DROP SCHEMA fa_file_storage CASCADE;
-DROP SCHEMA fa_error_record CASCADE;
+DROP SCHEMA IF EXISTS fa_customer CASCADE;
+DROP SCHEMA IF EXISTS fa_merchant CASCADE;
+DROP SCHEMA IF EXISTS fa_payment_instrument CASCADE;
+DROP SCHEMA IF EXISTS fa_provider CASCADE;
+DROP SCHEMA IF EXISTS fa_transaction CASCADE;
+DROP SCHEMA IF EXISTS fa_file_storage CASCADE;
+DROP SCHEMA IF EXISTS fa_error_record CASCADE;
+DROP SCHEMA IF EXISTS fa_mock CASCADE;

--- a/src/psql/migrations/DEV-CSTAR/fa/U2__fa_drop_constraints.sql
+++ b/src/psql/migrations/DEV-CSTAR/fa/U2__fa_drop_constraints.sql
@@ -67,6 +67,9 @@ ALTER TABLE ONLY fa_provider.fa_provider
 ALTER TABLE ONLY fa_error_record.fa_transaction_record
     DROP CONSTRAINT IF EXISTS pk_fa_transaction_record;
 
+-- FA_MOCK
+ALTER TABLE ONLY fa_mock.mock_provider
+	DROP CONSTRAINT IF EXISTS mock_provider_pk;
 
 
 ALTER DEFAULT PRIVILEGES FOR ROLE "${adminUser}" IN SCHEMA fa_customer GRANT ALL ON TABLES TO "${adminUser}";

--- a/src/psql/migrations/DEV-CSTAR/fa/V1__fa_create_schemas_and_tables.sql
+++ b/src/psql/migrations/DEV-CSTAR/fa/V1__fa_create_schemas_and_tables.sql
@@ -298,3 +298,27 @@ CREATE TABLE fa_error_record.fa_transaction_record (
 );
 
 ALTER TABLE fa_error_record.fa_transaction_record OWNER TO "FA_USER";
+
+-- FA_MOCK
+
+CREATE SCHEMA fa_mock;
+ALTER SCHEMA fa_mock OWNER TO "FA_USER";
+
+CREATE TABLE fa_mock.mock_provider (
+	transaction_date_t timestamptz(0) NOT NULL,
+	amount_i numeric NOT NULL,
+	bin_card_s varchar NOT NULL,
+	auth_code_s varchar NOT NULL,
+	terminal_id_s varchar(255) NOT NULL,
+	transaction_id_s varchar NOT NULL,
+	customer_data_s varchar NULL,
+	merchant_data_s varchar NULL,
+	customer_address_s varchar NULL,
+	merchant_address_s varchar NULL,
+	payment_lable_s varchar NULL,
+	dest_code_s varchar NULL,
+	acquirer_id_s varchar NULL,
+	contract_id_s varchar NULL
+);
+
+ALTER TABLE fa_mock.mock_provider OWNER TO "FA_USER";

--- a/src/psql/migrations/DEV-CSTAR/fa/V2__fa_create_contraints_and_privileges.sql
+++ b/src/psql/migrations/DEV-CSTAR/fa/V2__fa_create_contraints_and_privileges.sql
@@ -82,6 +82,11 @@ ALTER TABLE ONLY fa_provider.fa_provider
 ALTER TABLE ONLY fa_error_record.fa_transaction_record
     ADD CONSTRAINT pk_fa_transaction_record PRIMARY KEY (record_id_s);
 
+-- FA_MOCK
+ALTER TABLE ONLY fa_mock.mock_provider
+	ADD CONSTRAINT mock_provider_pk PRIMARY KEY (transaction_date_t, amount_i, bin_card_s, auth_code_s, terminal_id_s);
+
+
 ALTER DEFAULT PRIVILEGES FOR ROLE "${adminUser}" IN SCHEMA fa_customer REVOKE ALL ON TABLES FROM "${adminUser}";
 ALTER DEFAULT PRIVILEGES FOR ROLE "${adminUser}" IN SCHEMA fa_file_storage REVOKE ALL ON TABLES FROM "${adminUser}";
 ALTER DEFAULT PRIVILEGES FOR ROLE "${adminUser}" IN SCHEMA fa_merchant REVOKE ALL ON TABLES FROM "${adminUser}";


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
This PR proposes to modify 
- config-maps and secrets in `fa` k8s namespace, plus 
- Postgres Flexible Server migrations 
to support deployment of `cstariobackendtest` micro-service in `fa` k8s namespace

### List of changes

<!--- Describe your changes in detail -->
- A new configmap in `fa` k8s namespace
- A new secret in `fa` k8s namespace
- A new migration to create the schema `fa_mock` in the Postgres Flexible Server

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->
In order to migrate FA system in UAT, the micro-service `cstariobackendtest` should be moved in `fa` k8s namespace and should use the new DBMS for its data


### Type of changes

- [x] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
