### PR TITLE
[CEN-1356] Rename cstar prefix to rtd

### DIFF
--- a/src/api.tf
+++ b/src/api.tf
@@ -466,11 +466,11 @@ module "rtd_csv_transaction" {
       })
     },
     {
-      operation_id = "createCstarSasToken",
+      operation_id = "createRtdSasToken",
       xml_content = templatefile("./api/rtd_csv_transaction/create-sas-token-policy.xml.tpl", {
         blob-storage-access-key       = module.cstarblobstorage.primary_access_key,
         blob-storage-account-name     = module.cstarblobstorage.name,
-        blob-storage-container-prefix = "cstar-transactions"
+        blob-storage-container-prefix = "rtd-transactions"
       })
     },
     {

--- a/src/api/rtd_csv_transaction/openapi.json.tpl
+++ b/src/api/rtd_csv_transaction/openapi.json.tpl
@@ -61,11 +61,11 @@
                 }
             }
         },
-        "/cstar/sas": {
+        "/rtd/sas": {
             "post": {
                 "summary": "Creates a new SAS token",
-                "description": "A new SAS token granting r/w permission on CSTAR client's container",
-                "operationId": "createCstarSasToken",
+                "description": "A new SAS token granting r/w permission on RTD client's container",
+                "operationId": "createRtdSasToken",
                 "parameters": [],
                 "responses": {
                     "201": {


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
This PR renames the prefix "/cstar" to "/rtd" for the endpoints exposed under the API CSV Transaction, and accordingly the prefix for blobstorage containers created by the /rtd/sas endpoint.

### List of changes

<!--- Describe your changes in detail -->
Renamed cstar to rtd both on endpoint path and container prefix

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->
The RTD naming is more appropriate given the kind of transactions that the endpoint and the generated containers will handle.

### Type of changes

- [x] Add new resources
- [ ] Update configuration to existing resources
- [x] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
