### PR TITLE
[CEN-1361] Add event grid subscription and link it to event hub

### DIFF
--- a/src/env/dev/terraform.tfvars
+++ b/src/env/dev/terraform.tfvars
@@ -712,4 +712,4 @@ tags = {
 }
 
 enable_api_fa = true
-enable_blob_storgae_event_grid_integration = true
+enable_blob_storage_event_grid_integration = true

--- a/src/env/dev/terraform.tfvars
+++ b/src/env/dev/terraform.tfvars
@@ -712,3 +712,4 @@ tags = {
 }
 
 enable_api_fa = true
+enable_blob_storgae_event_grid_integration = true

--- a/src/env/dev/terraform.tfvars
+++ b/src/env/dev/terraform.tfvars
@@ -711,5 +711,5 @@ tags = {
   CostCenter  = "TS310 - PAGAMENTI & SERVIZI"
 }
 
-enable_api_fa = true
+enable_api_fa                              = true
 enable_blob_storage_event_grid_integration = true

--- a/src/env/dev/terraform.tfvars
+++ b/src/env/dev/terraform.tfvars
@@ -547,6 +547,28 @@ eventhubs = [
       }
     ]
   },
+  {
+    name              = "rtd-platform-events"
+    partitions        = 1
+    message_retention = 1
+    consumers         = ["rtd-platform-events-consumer-group"]
+    keys = [
+      {
+        # publisher
+        name   = "rtd-platform-events-pub"
+        listen = false
+        send   = true
+        manage = false
+      },
+      {
+        # subscriber
+        name   = "rtd-platform-events-sub"
+        listen = true
+        send   = false
+        manage = false
+      }
+    ]
+  },
 ]
 
 eventhubs_fa = [

--- a/src/events.tf
+++ b/src/events.tf
@@ -26,4 +26,8 @@ resource "azurerm_eventgrid_system_topic_event_subscription" "storage_subscripti
   resource_group_name = azurerm_resource_group.events_rg.name
 
   eventhub_endpoint_id = data.azurerm_eventhub.rtd_platform_eventhub.id
+
+  depends_on = [
+    azurerm_eventgrid_system_topic.storage_topic
+  ]
 }

--- a/src/events.tf
+++ b/src/events.tf
@@ -1,5 +1,5 @@
 resource "azurerm_eventgrid_system_topic" "storage_topic" {
-  count = contains(["d"], var.env_short) ? 1 : 0 
+  count                  = contains(["d"], var.env_short) ? 1 : 0
   name                   = format("%s-events-storage-topic", local.project)
   location               = var.location
   resource_group_name    = azurerm_resource_group.rg_storage.name
@@ -8,7 +8,7 @@ resource "azurerm_eventgrid_system_topic" "storage_topic" {
 }
 
 data "azurerm_eventhub" "rtd_platform_eventhub" {
-  count = contains(["d"], var.env_short) ? 1 : 0 
+  count               = contains(["d"], var.env_short) ? 1 : 0
   name                = "rtd-platform-events"
   resource_group_name = azurerm_resource_group.msg_rg.name
   namespace_name      = format("%s-evh-ns", local.project) # should be returned by the module
@@ -16,7 +16,7 @@ data "azurerm_eventhub" "rtd_platform_eventhub" {
 
 
 resource "azurerm_eventgrid_system_topic_event_subscription" "storage_subscription" {
-  count = contains(["d"], var.env_short) ? 1 : 0 
+  count               = contains(["d"], var.env_short) ? 1 : 0
   name                = format("%s-events-storage-subscription", local.project)
   system_topic        = azurerm_eventgrid_system_topic.storage_topic[count.index].name
   resource_group_name = azurerm_resource_group.rg_storage.name

--- a/src/events.tf
+++ b/src/events.tf
@@ -1,5 +1,5 @@
 resource "azurerm_eventgrid_system_topic" "storage_topic" {
-  count                  = contains(["d"], var.env_short) ? 1 : 0
+  count                  = var.enable_blob_storgae_event_grid_integration ? 1 : 0
   name                   = format("%s-events-storage-topic", local.project)
   location               = var.location
   resource_group_name    = azurerm_resource_group.rg_storage.name
@@ -8,7 +8,7 @@ resource "azurerm_eventgrid_system_topic" "storage_topic" {
 }
 
 data "azurerm_eventhub" "rtd_platform_eventhub" {
-  count               = contains(["d"], var.env_short) ? 1 : 0
+  count               = var.enable_blob_storgae_event_grid_integration ? 1 : 0
   name                = "rtd-platform-events"
   resource_group_name = azurerm_resource_group.msg_rg.name
   namespace_name      = format("%s-evh-ns", local.project) # should be returned by the module
@@ -16,7 +16,7 @@ data "azurerm_eventhub" "rtd_platform_eventhub" {
 
 
 resource "azurerm_eventgrid_system_topic_event_subscription" "storage_subscription" {
-  count               = contains(["d"], var.env_short) ? 1 : 0
+  count               = var.enable_blob_storgae_event_grid_integration ? 1 : 0
   name                = format("%s-events-storage-subscription", local.project)
   system_topic        = azurerm_eventgrid_system_topic.storage_topic[count.index].name
   resource_group_name = azurerm_resource_group.rg_storage.name

--- a/src/events.tf
+++ b/src/events.tf
@@ -1,0 +1,29 @@
+resource "azurerm_resource_group" "events_rg" {
+  name     = format("%s-events-rg", local.project)
+  location = var.location
+
+  tags = var.tags
+}
+
+resource "azurerm_eventgrid_system_topic" "storage_topic" {
+  name                   = format("%s-events-storage-topic", local.project)
+  location               = var.location
+  resource_group_name    = azurerm_resource_group.events_rg.name
+  source_arm_resource_id = module.cstarblobstorage.id
+  topic_type             = "Microsoft.Storage.StorageAccounts"
+}
+
+data "azurerm_eventhub" "rtd_platform_eventhub" {
+  name                = "rtd-platform-events"
+  resource_group_name = azurerm_resource_group.msg_rg.name
+  namespace_name      = format("%s-evh-ns", local.project) # should be returned by the module
+}
+
+
+resource "azurerm_eventgrid_system_topic_event_subscription" "storage_subscription" {
+  name                = format("%s-events-storage-subscription", local.project)
+  system_topic        = azurerm_eventgrid_system_topic.storage_topic.name
+  resource_group_name = azurerm_resource_group.events_rg.name
+
+  eventhub_endpoint_id = data.azurerm_eventhub.rtd_platform_eventhub.id
+}

--- a/src/events.tf
+++ b/src/events.tf
@@ -23,7 +23,7 @@ data "azurerm_eventhub" "rtd_platform_eventhub" {
 resource "azurerm_eventgrid_system_topic_event_subscription" "storage_subscription" {
   name                = format("%s-events-storage-subscription", local.project)
   system_topic        = azurerm_eventgrid_system_topic.storage_topic.name
-  resource_group_name = azurerm_resource_group.events_rg.name
+  resource_group_name = azurerm_resource_group.rg_storage.name
 
   eventhub_endpoint_id = data.azurerm_eventhub.rtd_platform_eventhub.id
 

--- a/src/events.tf
+++ b/src/events.tf
@@ -12,6 +12,9 @@ data "azurerm_eventhub" "rtd_platform_eventhub" {
   name                = "rtd-platform-events"
   resource_group_name = azurerm_resource_group.msg_rg.name
   namespace_name      = format("%s-evh-ns", local.project) # should be returned by the module
+  depends_on = [
+    module.event_hub
+  ]
 }
 
 

--- a/src/events.tf
+++ b/src/events.tf
@@ -8,7 +8,7 @@ resource "azurerm_resource_group" "events_rg" {
 resource "azurerm_eventgrid_system_topic" "storage_topic" {
   name                   = format("%s-events-storage-topic", local.project)
   location               = var.location
-  resource_group_name    = azurerm_resource_group.events_rg.name
+  resource_group_name    = azurerm_resource_group.rg_storage.name
   source_arm_resource_id = module.cstarblobstorage.id
   topic_type             = "Microsoft.Storage.StorageAccounts"
 }

--- a/src/events.tf
+++ b/src/events.tf
@@ -18,10 +18,10 @@ data "azurerm_eventhub" "rtd_platform_eventhub" {
 resource "azurerm_eventgrid_system_topic_event_subscription" "storage_subscription" {
   count = contains(["d"], var.env_short) ? 1 : 0 
   name                = format("%s-events-storage-subscription", local.project)
-  system_topic        = azurerm_eventgrid_system_topic.storage_topic.name
+  system_topic        = azurerm_eventgrid_system_topic.storage_topic[count.index].name
   resource_group_name = azurerm_resource_group.rg_storage.name
 
-  eventhub_endpoint_id = data.azurerm_eventhub.rtd_platform_eventhub.id
+  eventhub_endpoint_id = data.azurerm_eventhub.rtd_platform_eventhub[count.index].id
 
   depends_on = [
     azurerm_eventgrid_system_topic.storage_topic

--- a/src/events.tf
+++ b/src/events.tf
@@ -1,5 +1,5 @@
 resource "azurerm_eventgrid_system_topic" "storage_topic" {
-  count                  = var.enable_blob_storgae_event_grid_integration ? 1 : 0
+  count                  = var.enable_blob_storage_event_grid_integration ? 1 : 0
   name                   = format("%s-events-storage-topic", local.project)
   location               = var.location
   resource_group_name    = azurerm_resource_group.rg_storage.name
@@ -8,7 +8,7 @@ resource "azurerm_eventgrid_system_topic" "storage_topic" {
 }
 
 data "azurerm_eventhub" "rtd_platform_eventhub" {
-  count               = var.enable_blob_storgae_event_grid_integration ? 1 : 0
+  count               = var.enable_blob_storage_event_grid_integration ? 1 : 0
   name                = "rtd-platform-events"
   resource_group_name = azurerm_resource_group.msg_rg.name
   namespace_name      = format("%s-evh-ns", local.project) # should be returned by the module
@@ -16,7 +16,7 @@ data "azurerm_eventhub" "rtd_platform_eventhub" {
 
 
 resource "azurerm_eventgrid_system_topic_event_subscription" "storage_subscription" {
-  count               = var.enable_blob_storgae_event_grid_integration ? 1 : 0
+  count               = var.enable_blob_storage_event_grid_integration ? 1 : 0
   name                = format("%s-events-storage-subscription", local.project)
   system_topic        = azurerm_eventgrid_system_topic.storage_topic[count.index].name
   resource_group_name = azurerm_resource_group.rg_storage.name

--- a/src/events.tf
+++ b/src/events.tf
@@ -1,11 +1,5 @@
-resource "azurerm_resource_group" "events_rg" {
-  name     = format("%s-events-rg", local.project)
-  location = var.location
-
-  tags = var.tags
-}
-
 resource "azurerm_eventgrid_system_topic" "storage_topic" {
+  count = contains(["d"], var.env_short) ? 1 : 0 
   name                   = format("%s-events-storage-topic", local.project)
   location               = var.location
   resource_group_name    = azurerm_resource_group.rg_storage.name
@@ -14,6 +8,7 @@ resource "azurerm_eventgrid_system_topic" "storage_topic" {
 }
 
 data "azurerm_eventhub" "rtd_platform_eventhub" {
+  count = contains(["d"], var.env_short) ? 1 : 0 
   name                = "rtd-platform-events"
   resource_group_name = azurerm_resource_group.msg_rg.name
   namespace_name      = format("%s-evh-ns", local.project) # should be returned by the module
@@ -21,6 +16,7 @@ data "azurerm_eventhub" "rtd_platform_eventhub" {
 
 
 resource "azurerm_eventgrid_system_topic_event_subscription" "storage_subscription" {
+  count = contains(["d"], var.env_short) ? 1 : 0 
   name                = format("%s-events-storage-subscription", local.project)
   system_topic        = azurerm_eventgrid_system_topic.storage_topic.name
   resource_group_name = azurerm_resource_group.rg_storage.name

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -614,3 +614,9 @@ variable "enable_api_fa" {
   description = "If true, allows to generate the APIs for FA."
   default     = false
 }
+
+variable "enable_blob_storgae_event_grid_integration" {
+  type        = bool
+  description = "If true, allows to send Blob Storage events to a queue."
+  default     = false
+}

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -615,7 +615,7 @@ variable "enable_api_fa" {
   default     = false
 }
 
-variable "enable_blob_storgae_event_grid_integration" {
+variable "enable_blob_storage_event_grid_integration" {
   type        = bool
   description = "If true, allows to send Blob Storage events to a queue."
   default     = false


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
This PR proposes to add an `event grid` subscription to route event to an event hub, thus allowing to use _classic_ `k8s` microservices to implement _reactive_ systems.

### List of changes

<!--- Describe your changes in detail -->

- A new event hub to host platform events
- A new event grid subscription capable of routing events the the new event hub

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->
This PR is needed to implement reactive workflows to ingest acquirer transactions

### Type of changes

- [x] Add new resources
- [ ] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
