### PR TITLE
[CEN-1365] Modify BPD production DB to implement opt in status

### DIFF
--- a/src/env/dev/terraform.tfvars
+++ b/src/env/dev/terraform.tfvars
@@ -199,16 +199,16 @@ aks_metric_alerts = {
 
 cidr_vnet = ["10.1.0.0/16"]
 
-cidr_subnet_k8s          = ["10.1.0.0/17"]
-cidr_subnet_appgateway   = ["10.1.128.0/24"]
-cidr_subnet_db           = ["10.1.129.0/24"]
-cidr_subnet_azdoa        = ["10.1.130.0/24"]
-cidr_subnet_jumpbox      = ["10.1.131.0/24"]
-cidr_subnet_redis        = ["10.1.132.0/24"]
-cidr_subnet_vpn          = ["10.1.133.0/24"]
-cidr_subnet_dnsforwarder = ["10.1.134.0/29"]
-cidr_subnet_flex_dbms    = ["10.1.136.0/24"]
-cidr_subnet_storage_account           = ["10.1.137.0/24"]
+cidr_subnet_k8s             = ["10.1.0.0/17"]
+cidr_subnet_appgateway      = ["10.1.128.0/24"]
+cidr_subnet_db              = ["10.1.129.0/24"]
+cidr_subnet_azdoa           = ["10.1.130.0/24"]
+cidr_subnet_jumpbox         = ["10.1.131.0/24"]
+cidr_subnet_redis           = ["10.1.132.0/24"]
+cidr_subnet_vpn             = ["10.1.133.0/24"]
+cidr_subnet_dnsforwarder    = ["10.1.134.0/29"]
+cidr_subnet_flex_dbms       = ["10.1.136.0/24"]
+cidr_subnet_storage_account = ["10.1.137.0/24"]
 
 
 

--- a/src/env/prod/terraform.tfvars
+++ b/src/env/prod/terraform.tfvars
@@ -199,15 +199,15 @@ aks_metric_alerts = {
 # https://www.davidc.net/sites/default/subnets/subnets.html?network=10.1.0.0&mask=16&division=35.df9ccf000
 cidr_vnet = ["10.1.0.0/16"]
 
-cidr_subnet_k8s          = ["10.1.0.0/17"]
-cidr_subnet_appgateway   = ["10.1.128.0/24"]
-cidr_subnet_db           = ["10.1.129.0/24"]
-cidr_subnet_azdoa        = ["10.1.130.0/24"]
-cidr_subnet_jumpbox      = ["10.1.131.0/24"]
-cidr_subnet_redis        = ["10.1.132.0/24"]
-cidr_subnet_vpn          = ["10.1.133.0/24"]
-cidr_subnet_dnsforwarder = ["10.1.134.0/29"]
-cidr_subnet_flex_dbms    = ["10.1.136.0/24"]
+cidr_subnet_k8s             = ["10.1.0.0/17"]
+cidr_subnet_appgateway      = ["10.1.128.0/24"]
+cidr_subnet_db              = ["10.1.129.0/24"]
+cidr_subnet_azdoa           = ["10.1.130.0/24"]
+cidr_subnet_jumpbox         = ["10.1.131.0/24"]
+cidr_subnet_redis           = ["10.1.132.0/24"]
+cidr_subnet_vpn             = ["10.1.133.0/24"]
+cidr_subnet_dnsforwarder    = ["10.1.134.0/29"]
+cidr_subnet_flex_dbms       = ["10.1.136.0/24"]
 cidr_subnet_storage_account = ["10.1.137.0/24"]
 
 

--- a/src/env/uat/terraform.tfvars
+++ b/src/env/uat/terraform.tfvars
@@ -201,15 +201,15 @@ aks_metric_alerts = {
 # https://www.davidc.net/sites/default/subnets/subnets.html?network=10.1.0.0&mask=16&division=33.df9ce3000
 cidr_vnet = ["10.1.0.0/16"]
 
-cidr_subnet_k8s          = ["10.1.0.0/17"]
-cidr_subnet_appgateway   = ["10.1.128.0/24"]
-cidr_subnet_db           = ["10.1.129.0/24"]
-cidr_subnet_azdoa        = ["10.1.130.0/24"]
-cidr_subnet_jumpbox      = ["10.1.131.0/24"]
-cidr_subnet_vpn          = ["10.1.132.0/24"]
-cidr_subnet_dnsforwarder = ["10.1.133.0/29"]
-cidr_subnet_flex_dbms    = ["10.1.136.0/24"]
-cidr_subnet_storage_account           = ["10.1.137.0/24"]
+cidr_subnet_k8s             = ["10.1.0.0/17"]
+cidr_subnet_appgateway      = ["10.1.128.0/24"]
+cidr_subnet_db              = ["10.1.129.0/24"]
+cidr_subnet_azdoa           = ["10.1.130.0/24"]
+cidr_subnet_jumpbox         = ["10.1.131.0/24"]
+cidr_subnet_vpn             = ["10.1.132.0/24"]
+cidr_subnet_dnsforwarder    = ["10.1.133.0/29"]
+cidr_subnet_flex_dbms       = ["10.1.136.0/24"]
+cidr_subnet_storage_account = ["10.1.137.0/24"]
 
 
 # integration vnet

--- a/src/psql/flyway.sh
+++ b/src/psql/flyway.sh
@@ -35,12 +35,12 @@ fi
 az account set -s "${SUBSCRIPTION}"
 
 # shellcheck disable=SC1090
-source "${WORKDIR}/subscriptions/${SUBSCRIPTION}/backend.ini"
+# source "${WORKDIR}/subscriptions/${SUBSCRIPTION}/backend.ini"
 
 
 # shellcheck disable=SC2154
-printf "Subscription: %s\n" "${SUBSCRIPTION}"
-printf "Resource Group Name: %s\n" "${resource_group_name}"
+# printf "Subscription: %s\n" "${SUBSCRIPTION}"
+# printf "Resource Group Name: %s\n" "${resource_group_name}"
 
 keyvault_name=$(az keyvault list -o tsv --query "[?contains(name,'kv')].{Name:name}")
 psql_server_name=${DBMS}
@@ -63,7 +63,8 @@ export FLYWAY_URL="jdbc:postgresql://${psql_server_private_fqdn}:5432/${DATABASE
 export FLYWAY_USER="${user}"
 export FLYWAY_PASSWORD="${administrator_login_password}"
 export SERVER_NAME="${psql_server_name}"
-export FLYWAY_DOCKER_TAG="7.11.1-alpine"
+FLYWAY_VERSION="8.4.4"
+export FLYWAY_DOCKER_TAG="${FLYWAY_VERSION}-alpine"
 
 bpd_user_password=$(az keyvault secret show --name db-bpd-user-password --vault-name "${keyvault_name}" -o tsv --query value)
 rtd_user_password=$(az keyvault secret show --name db-rtd-user-password --vault-name "${keyvault_name}" -o tsv --query value)
@@ -93,23 +94,34 @@ export MONITORING_SIA_USER_PASSWORD="${monitoring_sia_user_password}"
 export MONITORING_OPERATION_USER_PASSWORD="${monitoring_operation_user_password}"
 export TKM_ACQUIRER_MANAGER_USER_PASSWORD="${tkm_acquirer_manager_user_password}"
 
-docker run --rm -it --network=host -v "${WORKDIR}/migrations/${SUBSCRIPTION}/${DATABASE}":/flyway/sql \
-  flyway/flyway:"${FLYWAY_DOCKER_TAG}" \
-  -url="${FLYWAY_URL}" -user="${FLYWAY_USER}" -password="${FLYWAY_PASSWORD}" \
+location="${WORKDIR}/migrations/${SUBSCRIPTION}/${DATABASE}"
+options="-url=${FLYWAY_URL} -user=${FLYWAY_USER} -password=${FLYWAY_PASSWORD} \
   -validateMigrationNaming=true \
-  -placeholders.adminUser="${administrator_login}" \
-  -placeholders.adminPassword="${administrator_login_password}" \
-  -placeholders.bpdUserPassword="${BPD_USER_PASSWORD}" \
-  -placeholders.rtdUserPassword="${RTD_USER_PASSWORD}" \
-  -placeholders.faUserPassword="${FA_USER_PASSWORD}" \
-  -placeholders.faPaymentInstrumentRemoteUserPassword="${FA_PAYMENT_INSTRUMENT_REMOTE_USER_PASSWORD}" \
-  -placeholders.bpdPaymentInstrumentRemoteUserPassword="${BPD_PAYMENT_INSTRUMENT_REMOTE_USER_PASSWORD}" \
-  -placeholders.bpdAwardPeriodRemoteUserPassword="${BPD_AWARD_PERIOD_REMOTE_USER_PASSWORD}" \
-  -placeholders.bpdWinningTransactionRemoteUserPassword="${BPD_WINNING_TRANSACTION_REMOTE_USER_PASSWORD}" \
-  -placeholders.dashboardPagopaUserPassword="${DASHBOARD_PAGOPA_USER_PASSWORD}" \
-  -placeholders.monitoringUserPassword="${MONITORING_USER_PASSWORD}" \
-  -placeholders.monitoringPdndUserPassword="${MONITORING_PDND_USER_PASSWORD}" \
-  -placeholders.monitoringSiaUserPassword="${MONITORING_SIA_USER_PASSWORD}" \
-  -placeholders.monitoringOperationUserPassword="${MONITORING_OPERATION_USER_PASSWORD}" \
-  -placeholders.tkmAcquirerManagerUserPassword="${TKM_ACQUIRER_MANAGER_USER_PASSWORD}" \
-  -placeholders.serverName="${SERVER_NAME}" "${COMMAND}" ${other}
+  -placeholders.adminUser=${administrator_login} \
+  -placeholders.adminPassword=${administrator_login_password} \
+  -placeholders.bpdUserPassword=${BPD_USER_PASSWORD} \
+  -placeholders.rtdUserPassword=${RTD_USER_PASSWORD} \
+  -placeholders.faUserPassword=${FA_USER_PASSWORD} \
+  -placeholders.faPaymentInstrumentRemoteUserPassword=${FA_PAYMENT_INSTRUMENT_REMOTE_USER_PASSWORD} \
+  -placeholders.bpdPaymentInstrumentRemoteUserPassword=${BPD_PAYMENT_INSTRUMENT_REMOTE_USER_PASSWORD} \
+  -placeholders.bpdAwardPeriodRemoteUserPassword=${BPD_AWARD_PERIOD_REMOTE_USER_PASSWORD} \
+  -placeholders.bpdWinningTransactionRemoteUserPassword=${BPD_WINNING_TRANSACTION_REMOTE_USER_PASSWORD} \
+  -placeholders.dashboardPagopaUserPassword=${DASHBOARD_PAGOPA_USER_PASSWORD} \
+  -placeholders.monitoringUserPassword=${MONITORING_USER_PASSWORD} \
+  -placeholders.monitoringPdndUserPassword=${MONITORING_PDND_USER_PASSWORD} \
+  -placeholders.monitoringSiaUserPassword=${MONITORING_SIA_USER_PASSWORD} \
+  -placeholders.monitoringOperationUserPassword=${MONITORING_OPERATION_USER_PASSWORD} \
+  -placeholders.tkmAcquirerManagerUserPassword=${TKM_ACQUIRER_MANAGER_USER_PASSWORD} \
+  -placeholders.serverName=${SERVER_NAME}"
+
+
+if [[ $(flyway -v) =~ ${FLYWAY_VERSION} ]]
+then
+  flyway -locations="filesystem:${location}" ${options} ${other} ${COMMAND}
+else
+docker run --rm -it --network=host -v ${location}:/flyway/sql \
+  flyway/flyway:${FLYWAY_DOCKER_TAG} \
+  ${options} ${COMMAND} ${other}
+fi
+
+

--- a/src/psql/migrations/PROD-CSTAR/bpd/U11__bpd.alter_citizen_drop_opt_in_status.sql
+++ b/src/psql/migrations/PROD-CSTAR/bpd/U11__bpd.alter_citizen_drop_opt_in_status.sql
@@ -1,0 +1,1 @@
+ALTER TABLE bpd_citizen.bpd_citizen DROP COLUMN opt_in_status_s;

--- a/src/psql/migrations/PROD-CSTAR/bpd/U11__bpd.alter_citizen_drop_opt_in_status.sql
+++ b/src/psql/migrations/PROD-CSTAR/bpd/U11__bpd.alter_citizen_drop_opt_in_status.sql
@@ -1,1 +1,0 @@
-ALTER TABLE bpd_citizen.bpd_citizen DROP COLUMN opt_in_status_s;

--- a/src/psql/migrations/PROD-CSTAR/bpd/V11__bpd.alter_citizen_add_opt_in_status.sql
+++ b/src/psql/migrations/PROD-CSTAR/bpd/V11__bpd.alter_citizen_add_opt_in_status.sql
@@ -1,0 +1,2 @@
+ALTER TABLE bpd_citizen.bpd_citizen ADD COLUMN opt_in_status_s VARCHAR(10);
+ALTER TABLE bpd_citizen.bpd_citizen ALTER COLUMN opt_in_status_s SET DEFAULT 'NOREQ';


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
This PR proposes to modify production DB to implement payment instruments opt-in status. The feature has been tested in UAT and has proven to be backward compatible with existing version of APP IO

### List of changes

<!--- Describe your changes in detail -->

- New column in citizen table to store the citizen state in the card opt in use case

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

- this PR allows to manage the payment instruments opt-in use case

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [x] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
