### PR TITLE
[CEN-1372] Tune alert on failed requests @appgw

### DIFF
--- a/src/network.tf
+++ b/src/network.tf
@@ -430,8 +430,8 @@ module "app_gw" {
           metric_name              = "FailedRequests"
           operator                 = "GreaterThan"
           alert_sensitivity        = "High"
-          evaluation_total_count   = 2
-          evaluation_failure_count = 2
+          evaluation_total_count   = 5
+          evaluation_failure_count = 4
           dimension                = []
         }
       ]


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
This PR proposes to tune the alert on failed requests as measured at app gateway

### List of changes

<!--- Describe your changes in detail -->

- Fire the alert when the dynamic threshold is violated in 4 of the last 5 periods

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->
This PR is motivated by the fact that the alert fires too often 

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
