### PR TITLE
[CEN-1405] Uniform internal APIM endpoint across subscriptions

### DIFF
--- a/src/dns_private.tf
+++ b/src/dns_private.tf
@@ -18,7 +18,7 @@ resource "azurerm_private_dns_zone_virtual_network_link" "private_integration_dn
 }
 
 resource "azurerm_private_dns_a_record" "private_dns_a_record_api" {
-  name                = module.apim.name
+  name                = "apim"
   zone_name           = azurerm_private_dns_zone.private_private_dns_zone.name
   resource_group_name = azurerm_resource_group.rg_vnet.name
   ttl                 = 300

--- a/src/env/dev/terraform.tfvars
+++ b/src/env/dev/terraform.tfvars
@@ -321,7 +321,8 @@ pgres_flex_params = {
 }
 
 
-dns_zone_prefix = "dev.cstar"
+dns_zone_prefix         = "dev.cstar"
+internal_private_domain = "internal.dev.cstar.pagopa.it"
 
 ehns_sku_name = "Standard"
 

--- a/src/env/uat/terraform.tfvars
+++ b/src/env/uat/terraform.tfvars
@@ -319,8 +319,9 @@ pgres_flex_params = {
 
 }
 
-dns_zone_prefix = "uat.cstar"
-ehns_sku_name   = "Standard"
+dns_zone_prefix         = "uat.cstar"
+internal_private_domain = "internal.uat.cstar.pagopa.it"
+ehns_sku_name           = "Standard"
 
 ehns_alerts_enabled = false
 ehns_metric_alerts = {

--- a/src/env/uat/terraform.tfvars
+++ b/src/env/uat/terraform.tfvars
@@ -320,7 +320,6 @@ pgres_flex_params = {
 }
 
 dns_zone_prefix         = "uat.cstar"
-internal_private_domain = "internal.uat.cstar.pagopa.it"
 ehns_sku_name           = "Standard"
 
 ehns_alerts_enabled = false

--- a/src/env/uat/terraform.tfvars
+++ b/src/env/uat/terraform.tfvars
@@ -319,8 +319,8 @@ pgres_flex_params = {
 
 }
 
-dns_zone_prefix         = "uat.cstar"
-ehns_sku_name           = "Standard"
+dns_zone_prefix = "uat.cstar"
+ehns_sku_name   = "Standard"
 
 ehns_alerts_enabled = false
 ehns_metric_alerts = {


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
The APIM internal hostname as defined in the internal DNS zone is not uniform across the various subscriptions at the moment. This PR proposes to adopt a uniform naming for it.

### List of changes

<!--- Describe your changes in detail -->
- add customisation of internal zone domain for DEV env
- change internal APIM hostname from 'cstar-X-apim' to 'apim' for all subscriptions

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->
Adopting a consistent naming scheme is beneficial.

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
