### PR TITLE
[CEN-1404] Add private custom domain

### DIFF
--- a/src/api.tf
+++ b/src/api.tf
@@ -79,6 +79,11 @@ resource "azurerm_api_management_custom_domain" "api_custom_domain" {
     )
   }
 
+  proxy {
+    host_name = trimsuffix(azurerm_private_dns_a_record.private_dns_a_record_api.fqdn, ".")
+    key_vault_id = azurerm_key_vault_certificate.apim_internal_custom_domain_cert.versionless_secret_id
+  }
+
   developer_portal {
     host_name = local.portal_domain
     key_vault_id = replace(
@@ -96,6 +101,10 @@ resource "azurerm_api_management_custom_domain" "api_custom_domain" {
       ""
     )
   }
+
+  depends_on = [
+    azurerm_key_vault_certificate.apim_internal_custom_domain_cert
+  ]
 }
 
 #########

--- a/src/api.tf
+++ b/src/api.tf
@@ -80,7 +80,7 @@ resource "azurerm_api_management_custom_domain" "api_custom_domain" {
   }
 
   proxy {
-    host_name = trimsuffix(azurerm_private_dns_a_record.private_dns_a_record_api.fqdn, ".")
+    host_name    = trimsuffix(azurerm_private_dns_a_record.private_dns_a_record_api.fqdn, ".")
     key_vault_id = azurerm_key_vault_certificate.apim_internal_custom_domain_cert.versionless_secret_id
   }
 

--- a/src/security.tf
+++ b/src/security.tf
@@ -171,6 +171,55 @@ resource "azurerm_user_assigned_identity" "appgateway" {
   tags = var.tags
 }
 
+resource "azurerm_key_vault_certificate" "apim_internal_custom_domain_cert" {
+  name         = format("%s-apim-private-custom-domain-cert", local.project)
+  key_vault_id = module.key_vault.id
+
+  certificate_policy {
+    issuer_parameters {
+      name = "Self"
+    }
+
+    key_properties {
+      exportable = true
+      key_size   = 2048
+      key_type   = "RSA"
+      reuse_key  = true
+    }
+
+    lifetime_action {
+      action {
+        action_type = "AutoRenew"
+      }
+
+      trigger {
+        days_before_expiry = 30
+      }
+    }
+
+    secret_properties {
+      content_type = "application/x-pkcs12"
+    }
+
+    x509_certificate_properties {
+      # Server Authentication = 1.3.6.1.5.5.7.3.1
+      # Client Authentication = 1.3.6.1.5.5.7.3.2
+      extended_key_usage = ["1.3.6.1.5.5.7.3.1"]
+      key_usage = [
+        "cRLSign",
+        "dataEncipherment",
+        "digitalSignature",
+        "keyAgreement",
+        "keyCertSign",
+        "keyEncipherment",
+      ]
+
+      subject            = format("CN=%s", trimsuffix(azurerm_private_dns_a_record.private_dns_a_record_api.fqdn, "."))
+      validity_in_months = 12
+    }
+  }
+}
+
 data "azurerm_key_vault_certificate" "app_gw_io_cstar" {
   count        = var.app_gateway_api_io_certificate_name != null ? 1 : 0
   name         = var.app_gateway_api_io_certificate_name


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
This PR adds a new custom domain matching the internal DNS APIM name. This new domain allows to serve requests originated from internal services without the necessity of routing the requests through the publicly exposed endpoint.

### List of changes

<!--- Describe your changes in detail -->
- add a self-signed certificate for internal use only
- add a new custom domain registered on the internal DNS name of the APIM

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->
- Allow internal applications to communicate to the APIM without relying on the publicly accessible URL.

### Type of changes

- [x] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
