### PR TITLE
[CEN-1406] Use only storage private endpoint in RTD CSV Transaction APIs

### DIFF
--- a/src/api.tf
+++ b/src/api.tf
@@ -461,7 +461,7 @@ module "rtd_csv_transaction" {
   path         = "rtd/csv-transaction"
   protocols    = ["https"]
 
-  service_url = format("https://%s", module.cstarblobstorage.primary_blob_host)
+  service_url = format("https://%s", azurerm_private_endpoint.blob_storage_pe.private_dns_zone_configs[0].record_sets[0].fqdn)
 
   content_format = "openapi"
   content_value = templatefile("./api/rtd_csv_transaction/openapi.json.tpl", {
@@ -479,6 +479,7 @@ module "rtd_csv_transaction" {
       xml_content = templatefile("./api/rtd_csv_transaction/create-sas-token-policy.xml.tpl", {
         blob-storage-access-key       = module.cstarblobstorage.primary_access_key,
         blob-storage-account-name     = module.cstarblobstorage.name,
+        blob-storage-private-fqdn     = azurerm_private_endpoint.blob_storage_pe.private_dns_zone_configs[0].record_sets[0].fqdn,
         blob-storage-container-prefix = "ade-transactions"
       })
     },
@@ -487,6 +488,7 @@ module "rtd_csv_transaction" {
       xml_content = templatefile("./api/rtd_csv_transaction/create-sas-token-policy.xml.tpl", {
         blob-storage-access-key       = module.cstarblobstorage.primary_access_key,
         blob-storage-account-name     = module.cstarblobstorage.name,
+        blob-storage-private-fqdn     = azurerm_private_endpoint.blob_storage_pe.private_dns_zone_configs[0].record_sets[0].fqdn,
         blob-storage-container-prefix = "rtd-transactions"
       })
     },
@@ -513,7 +515,7 @@ module "rtd_csv_transaction_decrypted" {
   path         = "rtd/csv-transaction-decrypted"
   protocols    = ["https"]
 
-  service_url = format("https://%s", module.cstarblobstorage.primary_blob_host)
+  service_url = format("https://%s", azurerm_private_endpoint.blob_storage_pe.private_dns_zone_configs[0].record_sets[0].fqdn)
 
   content_format = "openapi"
   content_value = templatefile("./api/rtd_csv_transaction_decrypted/openapi.json.tpl", {

--- a/src/api/rtd_csv_transaction/create-sas-token-policy.xml.tpl
+++ b/src/api/rtd_csv_transaction/create-sas-token-policy.xml.tpl
@@ -23,6 +23,7 @@
         <!-- Storage related variables -->
         <set-variable name="accessKey" value="${blob-storage-access-key}" />
         <set-variable name="storageAccount" value="${blob-storage-account-name}" />
+        <set-variable name="storagePrivateFqdn" value="${blob-storage-private-fqdn}" />
         <set-variable name="containerPrefix" value="${blob-storage-container-prefix}" />
 
         <!-- SAS Token variables -->
@@ -119,7 +120,7 @@
             START - Perform a PUT operation on the storage REST endpoint
         -->
         <set-variable name="createContainerUrl" value="@{
-                return "https://" + context.Variables["storageAccount"] + ".blob.core.windows.net/" + context.Variables["containerName"] + "?restype=container";
+                return "https://" + context.Variables["storagePrivateFqdn"] + "/" + context.Variables["containerName"] + "?restype=container";
             }"
         />
 


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
This PR modify the "RTD CSV Transaction" and "RTD CSV Transaction Decrypted" to explicitly communicate to the storage account via private endpoint. At the moment the APIs are already using the private endpoint but relying on the fact the public endpoint is transparently resolved with the internal IP by the private network internal DNS.

### List of changes

<!--- Describe your changes in detail -->
- explicitly set blob storage name to the private FQDN

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->
- Referring to the storage via public endpoint is misleading and could possibly pose security concerns in case of misconfiguration

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
