### PR TITLE
[CEN-1451] Add consumer group for eventhub rtd-platform-events

### DIFF
--- a/src/env/dev/terraform.tfvars
+++ b/src/env/dev/terraform.tfvars
@@ -551,7 +551,7 @@ eventhubs = [
     name              = "rtd-platform-events"
     partitions        = 1
     message_retention = 1
-    consumers         = ["rtd-platform-events-consumer-group"]
+    consumers         = ["rtd-decrypter-consumer-group", "rtd-ingestor-consumer-group"]
     keys = [
       {
         # publisher


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
This PR proposes to add a new consumer group for rtd-platform-events eventhub

### List of changes

<!--- Describe your changes in detail -->
- New consumer group for rtd-platform-event eventhub

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

Different microservices need an independent view of the eventhub  rtd-platform-events


### Type of changes

- [ ] Add anew resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
