### PR TITLE
[CEN-1431] Fix get-hashed-pans policy

### DIFF
--- a/src/api_rtd.tf
+++ b/src/api_rtd.tf
@@ -114,7 +114,8 @@ module "rtd_payment_instrument_manager" {
       operation_id = "get-hashed-pans",
       xml_content = templatefile("./api/rtd_payment_instrument_manager/get-hashed-pans_policy.xml.tpl", {
         # as-is due an application error in prod -->  to-be
-        host = var.env_short == "p" ? "prod.cstar.pagopa.it" : trim(azurerm_dns_a_record.dns_a_appgw_api.fqdn, ".")
+        # host = var.env_short == "p" ? "prod.cstar.pagopa.it" : trim(azurerm_dns_a_record.dns_a_appgw_api.fqdn, ".")
+        host = trim(azurerm_dns_a_record.dns_a_appgw_api.fqdn, ".")
       })
     },
   ]


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

This PR proposes to fix the policy of operation `get-hashed-pans`

### List of changes

<!--- Describe your changes in detail -->
- Remove conditional to set host to `prod.cstar.pagopa.it` in production

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

This PR solves a failure in TLS handshaking

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
