### PR TITLE
[CEN-1538] Add PM response body when Card enrolling fails

### DIFF
--- a/src/api/fa_hb_payment_instruments/enrollmentUsingPUT_Card_policy.xml.tpl
+++ b/src/api/fa_hb_payment_instruments/enrollmentUsingPUT_Card_policy.xml.tpl
@@ -73,7 +73,7 @@
                     <otherwise>
                         <return-response>
                             <set-status code="@(((IResponse)context.Variables["hpan"]).StatusCode)" reason="ErrorPM" />
-                            <set-body>@(((IResponse)context.Variables["hpan"]).Body)</set-body>
+                            <set-body>@(((IResponse)context.Variables["hpan"]).Body.As<JObject>())</set-body>
                         </return-response>
                     </otherwise>
                 </choose>

--- a/src/api/fa_hb_payment_instruments/enrollmentUsingPUT_Card_policy.xml.tpl
+++ b/src/api/fa_hb_payment_instruments/enrollmentUsingPUT_Card_policy.xml.tpl
@@ -73,6 +73,7 @@
                     <otherwise>
                         <return-response>
                             <set-status code="@(((IResponse)context.Variables["hpan"]).StatusCode)" reason="ErrorPM" />
+                            <set-body>@(((IResponse)context.Variables["hpan"]).Body.As<JObject>())</set-body>
                         </return-response>
                     </otherwise>
                 </choose>

--- a/src/api/fa_hb_payment_instruments/enrollmentUsingPUT_Card_policy.xml.tpl
+++ b/src/api/fa_hb_payment_instruments/enrollmentUsingPUT_Card_policy.xml.tpl
@@ -73,7 +73,7 @@
                     <otherwise>
                         <return-response>
                             <set-status code="@(((IResponse)context.Variables["hpan"]).StatusCode)" reason="ErrorPM" />
-                            <set-body>@(((IResponse)context.Variables["hpan"]).Body.As<JObject>())</set-body>
+                            <set-body>@(((IResponse)context.Variables["hpan"]).Body.As<JObject>().ToString())</set-body>
                         </return-response>
                     </otherwise>
                 </choose>

--- a/src/api/fa_hb_payment_instruments/enrollmentUsingPUT_Card_policy.xml.tpl
+++ b/src/api/fa_hb_payment_instruments/enrollmentUsingPUT_Card_policy.xml.tpl
@@ -73,7 +73,7 @@
                     <otherwise>
                         <return-response>
                             <set-status code="@(((IResponse)context.Variables["hpan"]).StatusCode)" reason="ErrorPM" />
-                            <set-body>@(((IResponse)context.Variables["hpan"]).Body.As<JObject>())</set-body>
+                            <set-body>@(((IResponse)context.Variables["hpan"]).Body)</set-body>
                         </return-response>
                     </otherwise>
                 </choose>


### PR DESCRIPTION
This PR proposes to improve observability of PM responses when a new payment instrument in enrolled.

### List of changes

<!--- Describe your changes in detail -->
- Modify apim policy of API PUT card in Payment Instruments.

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->
When an enrollement of a new payment instrument fails, the client doesn't know if the error is from CSTAR or PM.

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
