### PR TITLE
[CEN-1558] add rule to address cstariobackendtest in FA context

### DIFF
--- a/src/k8s/bpd_ingress.tf
+++ b/src/k8s/bpd_ingress.tf
@@ -66,14 +66,6 @@ resource "kubernetes_ingress" "bpd_ingress" {
 
         path {
           backend {
-            service_name = "cstariobackendtest"
-            service_port = var.default_service_port
-          }
-          path = "/cstariobackendtest/(.*)"
-        }
-
-        path {
-          backend {
             service_name = "bpdmstransactionerrormanager"
             service_port = var.default_service_port
           }

--- a/src/k8s/fa_ingress.tf
+++ b/src/k8s/fa_ingress.tf
@@ -95,6 +95,14 @@ resource "kubernetes_ingress" "fa_ingress" {
           }
           path = "/famstransactionerrormanager/(.*)"
         }
+        
+        path {
+          backend {
+            service_name = "cstariobackendtest"
+            service_port = var.default_service_port
+          }
+          path = "/cstariobackendtest/(.*)"
+        }
       }
     }
   }

--- a/src/k8s/fa_ingress.tf
+++ b/src/k8s/fa_ingress.tf
@@ -95,7 +95,7 @@ resource "kubernetes_ingress" "fa_ingress" {
           }
           path = "/famstransactionerrormanager/(.*)"
         }
-        
+
         path {
           backend {
             service_name = "cstariobackendtest"

--- a/src/k8s/subscriptions/DEV-CSTAR/terraform.tfvars
+++ b/src/k8s/subscriptions/DEV-CSTAR/terraform.tfvars
@@ -306,9 +306,7 @@ configmaps_fainvoicemanager = {
   POSTGRES_SHOW_SQL                                      = "true"
   LOG_LEVEL_FA_INVOICE_MANAGER                           = "DEBUG"
   MS_AGENZIA_ENTRATE_HOST                                = "cstariobackendtest"
-  MS_AGENZIA_ENTRATE_URL                                 = "http://cstariobackendtest/partita-iva/v0/verifica/"
-  MS_AGENZIA_ENTRATE_PORT                                = ""
-  MS_AGENZIA_ENTRATE_SCHEMA                              = "https"
+  MS_AGENZIA_ENTRATE_URL                                 = "http://cstariobackendtest:8080"
 }
 
 configmaps_fainvoiceprovider = {

--- a/src/k8s/subscriptions/DEV-CSTAR/terraform.tfvars
+++ b/src/k8s/subscriptions/DEV-CSTAR/terraform.tfvars
@@ -307,6 +307,9 @@ configmaps_fainvoicemanager = {
   LOG_LEVEL_FA_INVOICE_MANAGER                           = "DEBUG"
   MS_AGENZIA_ENTRATE_HOST                                = "cstariobackendtest"
   MS_AGENZIA_ENTRATE_URL                                 = "http://cstariobackendtest:8080"
+  # the two rows below are ignored if MS_AGENZIA_ENTRATE_URL has already been set 
+  MS_AGENZIA_ENTRATE_PORT                                = ""
+  MS_AGENZIA_ENTRATE_SCHEMA                              = "https"
 }
 
 configmaps_fainvoiceprovider = {

--- a/src/k8s/subscriptions/DEV-CSTAR/terraform.tfvars
+++ b/src/k8s/subscriptions/DEV-CSTAR/terraform.tfvars
@@ -305,6 +305,10 @@ configmaps_fainvoicemanager = {
   POSTGRES_POOLSIZE                                      = "2"
   POSTGRES_SHOW_SQL                                      = "true"
   LOG_LEVEL_FA_INVOICE_MANAGER                           = "DEBUG"
+  MS_AGENZIA_ENTRATE_HOST                                = "cstariobackendtest"
+  MS_AGENZIA_ENTRATE_URL                                 = "http://cstariobackendtest/partita-iva/v0/verifica/"
+  MS_AGENZIA_ENTRATE_PORT                                = ""
+  MS_AGENZIA_ENTRATE_SCHEMA                              = "https"
 }
 
 configmaps_fainvoiceprovider = {

--- a/src/k8s/subscriptions/DEV-CSTAR/terraform.tfvars
+++ b/src/k8s/subscriptions/DEV-CSTAR/terraform.tfvars
@@ -308,8 +308,8 @@ configmaps_fainvoicemanager = {
   MS_AGENZIA_ENTRATE_HOST                                = "cstariobackendtest"
   MS_AGENZIA_ENTRATE_URL                                 = "http://cstariobackendtest:8080"
   # the two rows below are ignored if MS_AGENZIA_ENTRATE_URL has already been set 
-  MS_AGENZIA_ENTRATE_PORT                                = ""
-  MS_AGENZIA_ENTRATE_SCHEMA                              = "https"
+  MS_AGENZIA_ENTRATE_PORT   = ""
+  MS_AGENZIA_ENTRATE_SCHEMA = "https"
 }
 
 configmaps_fainvoiceprovider = {

--- a/src/k8s/subscriptions/UAT-CSTAR/terraform.tfvars
+++ b/src/k8s/subscriptions/UAT-CSTAR/terraform.tfvars
@@ -338,6 +338,10 @@ configmaps_fainvoicemanager = {
   POSTGRES_POOLSIZE                                      = "2"
   POSTGRES_SHOW_SQL                                      = "true"
   LOG_LEVEL_FA_INVOICE_MANAGER                           = "INFO"
+  MS_AGENZIA_ENTRATE_HOST                                = "cstariobackendtest"
+  MS_AGENZIA_ENTRATE_URL                                 = "http://cstariobackendtest/partita-iva/v0/verifica/"
+  MS_AGENZIA_ENTRATE_PORT                                = ""
+  MS_AGENZIA_ENTRATE_SCHEMA                              = "https"
 }
 
 configmaps_fainvoiceprovider = {

--- a/src/k8s/subscriptions/UAT-CSTAR/terraform.tfvars
+++ b/src/k8s/subscriptions/UAT-CSTAR/terraform.tfvars
@@ -339,9 +339,7 @@ configmaps_fainvoicemanager = {
   POSTGRES_SHOW_SQL                                      = "true"
   LOG_LEVEL_FA_INVOICE_MANAGER                           = "INFO"
   MS_AGENZIA_ENTRATE_HOST                                = "cstariobackendtest"
-  MS_AGENZIA_ENTRATE_URL                                 = "http://cstariobackendtest/partita-iva/v0/verifica/"
-  MS_AGENZIA_ENTRATE_PORT                                = ""
-  MS_AGENZIA_ENTRATE_SCHEMA                              = "https"
+  MS_AGENZIA_ENTRATE_URL                                 = "http://cstariobackendtest:8080"
 }
 
 configmaps_fainvoiceprovider = {


### PR DESCRIPTION
This PR adds a rule to address cstariobackendtest in FA context and change invoice manager environment (only in DEV and UAT) to point to the AdE mock API.

<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes
- Edit ingress to route cstariobackendtest in fa namepace
- Remove ingress rule that routes requests to cstariobackendtest  in bpd namespace
- Edit configmaps of DEV and UAT to change AdE URL to mock service
<!--- Describe your changes in detail -->

### Motivation and context

To carry out some loads tests it's necessary mocking AdE endpoints instead of use real endpoint.
<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

