### PR TITLE
[CDC-65] Remove year in POST response when it returns 400

### DIFF
--- a/src/api/cdc/openapi.io.yml.tpl
+++ b/src/api/cdc/openapi.io.yml.tpl
@@ -114,13 +114,10 @@ components:
     RichiestaCartaErrata:
       type: object
       required:
-        - annoRiferimento
         - status
       properties:
         type:
           type: string
-        annoRiferimento:
-          $ref: '#/components/schemas/Anno'
         title:
           type: string
         status:


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
Update CdcC IO Swagger

### List of changes

<!--- Describe your changes in detail -->
- Remove year in POST response when it returns 400

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

year, in case of failure, doesn't convey any useful information

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
