### PR TITLE
[RTD-112] Create secret containing mongo DB connection string

### DIFF
--- a/src/k8s/rtd_secrets.tf
+++ b/src/k8s/rtd_secrets.tf
@@ -127,13 +127,14 @@ resource "kubernetes_secret" "rtd-postgres-credentials" {
 }
 
 resource "kubernetes_secret" "mongo_db_credentials" {
+  count = var.enable.rtd.file_register ? 1 : 0
   metadata {
-    name      = "postgres-credentials"
+    name      = "mongo-credentials"
     namespace = kubernetes_namespace.rtd.metadata[0].name
   }
 
   data = {
-    MONGODB_CONNECTION_URI = module.key_vault_secrets_query.values["mongo-db-connection-uri"].value
+    MONGODB_KEY = module.key_vault_secrets_query.values["mongo-db-key"].value
   }
 
   type = "Opaque"

--- a/src/k8s/rtd_secrets.tf
+++ b/src/k8s/rtd_secrets.tf
@@ -126,6 +126,19 @@ resource "kubernetes_secret" "rtd-postgres-credentials" {
   type = "Opaque"
 }
 
+resource "kubernetes_secret" "mongo_db_credentials" {
+  metadata {
+    name      = "postgres-credentials"
+    namespace = kubernetes_namespace.rtd.metadata[0].name
+  }
+
+  data = {
+    MONGODB_CONNECTION_URI = module.key_vault_secrets_query.values["mongo-db-connection-uri"].value
+  }
+
+  type = "Opaque"
+}
+
 # not yet used by any deployment, but maybe useful for the future
 resource "kubernetes_secret" "rtd-application-insights" {
   metadata {

--- a/src/k8s/subscriptions/DEV-CSTAR/terraform.tfvars
+++ b/src/k8s/subscriptions/DEV-CSTAR/terraform.tfvars
@@ -453,7 +453,8 @@ secrets_to_be_read_from_kv = [
   "tae-ade-api-client-secret",
   "cstarblobstorage-private-key",
   "cstarblobstorage-private-key-passphrase",
-  "rtd-internal-api-product-subscription-key"
+  "rtd-internal-api-product-subscription-key",
+  "mongo-db-connection-uri"
 ]
 
 enable = {
@@ -462,6 +463,7 @@ enable = {
     internal_api                        = true
     csv_transaction_apis                = true
     ingestor                            = true
+    file_register                       = true
   }
   fa = {
     api = true

--- a/src/k8s/subscriptions/DEV-CSTAR/terraform.tfvars
+++ b/src/k8s/subscriptions/DEV-CSTAR/terraform.tfvars
@@ -454,7 +454,7 @@ secrets_to_be_read_from_kv = [
   "cstarblobstorage-private-key",
   "cstarblobstorage-private-key-passphrase",
   "rtd-internal-api-product-subscription-key",
-  "mongo-db-connection-uri"
+  "mongo-db-key"
 ]
 
 enable = {

--- a/src/k8s/subscriptions/PROD-CSTAR/terraform.tfvars
+++ b/src/k8s/subscriptions/PROD-CSTAR/terraform.tfvars
@@ -652,6 +652,7 @@ enable = {
     internal_api                        = true
     csv_transaction_apis                = true
     ingestor                            = false
+    file_register                       = false
   }
   fa = {
     api = false

--- a/src/k8s/subscriptions/UAT-CSTAR/terraform.tfvars
+++ b/src/k8s/subscriptions/UAT-CSTAR/terraform.tfvars
@@ -486,6 +486,7 @@ enable = {
     internal_api                        = true
     csv_transaction_apis                = true
     ingestor                            = false
+    file_register                       = false
   }
   fa = {
     api = true

--- a/src/k8s/variables.tf
+++ b/src/k8s/variables.tf
@@ -237,6 +237,7 @@ variable "enable" {
       internal_api                        = bool
       csv_transaction_apis                = bool
       ingestor                            = bool
+      file_register                       = bool
     })
     fa = object({
       api = bool
@@ -249,6 +250,7 @@ variable "enable" {
       internal_api                        = false
       csv_transaction_apis                = false
       ingestor                            = false
+      file_register                       = false
     }
     fa = {
       api = false


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

This PR proposes to store in a aks secret the mongo DB connection string

### List of changes

<!--- Describe your changes in detail -->
- new key vault secret containing mongodb connection string
- new k8s secret referencing the key vault secret

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->
This PR enables microservices to use a non relational datastore

### Type of changes

- [x] Add new resources
- [ ] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
