### PR TITLE
[RTD-113] Add ingress mapping for RTD file register micro-service

### DIFF
--- a/src/k8s/rtd_ingress.tf
+++ b/src/k8s/rtd_ingress.tf
@@ -28,6 +28,17 @@ resource "kubernetes_ingress_v1" "rtd_ingress" {
           path = "/rtdmspaymentinstrumentmanager/(.*)"
         }
 
+        path {
+          backend {
+            service {
+              name = "rtdmsfileregister"
+              port {
+                number = var.default_service_port
+              }
+            }
+          }
+          path = "/rtdmsfileregister/(.*)"
+        }
 
       }
     }


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
This PR propose the addition of a mapping on the k8s ingress.
Through this we can exposing an endpoint for the new micro-service rtdmsfileregister.
### List of changes

<!--- Describe your changes in detail -->
- add a mapping to rtd ingress
### Motivation and context
We want to internally expose the micro service in order to assess the proper functioning of the DB.
<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
