### PR TITLE
[RTD-128] Add k8s subnet to CosmosDB allowed virtual networks

### DIFF
--- a/src/database.tf
+++ b/src/database.tf
@@ -158,6 +158,10 @@ module "cosmosdb_account_mongodb" {
   private_dns_zone_ids              = [azurerm_private_dns_zone.cosmos_mongo[count.index].id]
   is_virtual_network_filter_enabled = var.cosmos_mongo_db_params.is_virtual_network_filter_enabled
 
+  allowed_virtual_network_subnet_ids = [
+    module.k8s_snet.id
+  ]
+
   consistency_policy               = var.cosmos_mongo_db_params.consistency_policy
   main_geo_location_location       = azurerm_resource_group.db_rg.location
   main_geo_location_zone_redundant = var.cosmos_mongo_db_params.main_geo_location_zone_redundant

--- a/src/network.tf
+++ b/src/network.tf
@@ -73,7 +73,8 @@ module "k8s_snet" {
 
   service_endpoints = [
     "Microsoft.Web",
-    "Microsoft.Storage"
+    "Microsoft.Storage",
+    "Microsoft.AzureCosmosDB",
   ]
 }
 


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
This PR propose to add k8s subnet to the allowed virtual networks of the CosmosDB instance.
Also the CosmosDB service endpoint is allowed on k8s snet. 

### List of changes
<!--- Describe your changes in detail -->
- add k8s_snet to the allowed CosmosDB virtual networks.
- add CosmosDB service endpoint among the allowed ones in k8s snet. 

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->
With this change the CosmosDB instance can receive traffic from the k8s snet.

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
