### PR TITLE
[CDC-29] update caching policy to use as a key the bpd-token

### DIFF
--- a/src/api/cdc/get-stato-beneficiario_policy.xml
+++ b/src/api/cdc/get-stato-beneficiario_policy.xml
@@ -1,7 +1,7 @@
 <policies>
     <inbound>
         <base />
-        <set-variable name="token" value="@(context.Request.Headers.GetValueOrDefault("Authorization","scheme param").Split(' ').Last())" />
+        <set-variable name="token" value="@(context.Request.Headers.GetValueOrDefault("x-bpd-token","bpd-token").Split(' ').Last())" />
         <cache-lookup-value key="@((string)context.Variables["token"] + "-cdc-get-stato-beneficiario")" variable-name="statoBeneficiario"  />
         <choose>
             <!-- If the response is cached, return it and stop policy execution -->
@@ -16,9 +16,9 @@
     <outbound>
         <base />
         <set-variable name="isCacheable" value="@{
-            var response = context.Response.Body.As<JObject>();
+            var response = context.Response.Body.As<JObject>(preserveContent: true);
             var listaStatoPerAnno = (JArray)response["listaStatoPerAnno"];
-            bool isCacheable = (listaStatoPerAnno.Count == 3 && listaStatoPerAnno.Contains("ATTIVABILE")) ? true: false;
+            bool isCacheable = (listaStatoPerAnno.Count == 3 && !listaStatoPerAnno.Contains("ATTIVABILE")) ? true: false;
             return isCacheable;
         }"/>
         <choose>

--- a/src/api/cdc/policy.jwt.xml.tpl
+++ b/src/api/cdc/policy.jwt.xml.tpl
@@ -10,6 +10,12 @@
       <value>{{x-ibm-client-id}}</value>
     </set-header>
     <set-header name="Ocp-Apim-Subscription-Key" exists-action="delete" />
+    <set-header name="x-bpd-token" exists-action="override">
+      <value>@{
+        return context.Request.Headers.GetValueOrDefault("Authorization","scheme param").Split(' ').Last();
+      }
+      </value>
+    </set-header>
     <set-header name="Authorization" exists-action="override">
       <value>@{
       var JOSEProtectedHeader = Convert.ToBase64String(Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
This PR proposes to fix caching policy by using as a key the bpd token.

### List of changes

<!--- Describe your changes in detail -->
- cache key is now the bpd token + endpoint name since the jws token is modified at each request so results always in a cache miss
- change the logical condition to cache


### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

This PR is motivated by the fact that caching can't work if the key changes at each and every request

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
