### PR TITLE
[TAE-44] Add API to download sender ade ack files

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -84,6 +84,7 @@
 | <a name="module_rtd_fake_abi_to_fiscal_code"></a> [rtd\_fake\_abi\_to\_fiscal\_code](#module\_rtd\_fake\_abi\_to\_fiscal\_code) | git::https://github.com/pagopa/azurerm.git//api_management_api | v2.16.0 |
 | <a name="module_rtd_payment_instrument"></a> [rtd\_payment\_instrument](#module\_rtd\_payment\_instrument) | git::https://github.com/pagopa/azurerm.git//api_management_api | v1.0.16 |
 | <a name="module_rtd_payment_instrument_manager"></a> [rtd\_payment\_instrument\_manager](#module\_rtd\_payment\_instrument\_manager) | git::https://github.com/pagopa/azurerm.git//api_management_api | v1.0.16 |
+| <a name="module_rtd_senderack_download_file"></a> [rtd\_senderack\_download\_file](#module\_rtd\_senderack\_download\_file) | git::https://github.com/pagopa/azurerm.git//api_management_api | v2.18.3 |
 | <a name="module_rtd_senderadeack_filename_list"></a> [rtd\_senderadeack\_filename\_list](#module\_rtd\_senderadeack\_filename\_list) | git::https://github.com/pagopa/azurerm.git//api_management_api | v2.16.0 |
 | <a name="module_sftp"></a> [sftp](#module\_sftp) | git::https://github.com/pagopa/azurerm.git//storage_account | v2.18.0 |
 | <a name="module_storage_account_snet"></a> [storage\_account\_snet](#module\_storage\_account\_snet) | git::https://github.com/pagopa/azurerm.git//subnet | v2.1.13 |

--- a/src/api/rtd_senderack_download_file/azureblob_policy.xml
+++ b/src/api/rtd_senderack_download_file/azureblob_policy.xml
@@ -1,0 +1,25 @@
+
+                    
+<policies>
+    <inbound>
+      <base />
+      <authentication-managed-identity resource="https://storage.azure.com/" output-token-variable-name="msi-access-token" ignore-error="false" />
+      <set-header name="X-Ms-Version" exists-action="override">
+        <value>2019-12-12</value>
+      </set-header>
+ 
+      <set-header name="Authorization" exists-action="override">
+        <value>@("Bearer " + (string)context.Variables["msi-access-token"])</value>
+      </set-header>
+      
+    </inbound>
+    <backend>
+        <base />
+    </backend>
+    <outbound>
+        <base />
+    </outbound>
+    <on-error>
+        <base />
+    </on-error>
+</policies>

--- a/src/api/rtd_senderack_download_file/openapi.json.tpl
+++ b/src/api/rtd_senderack_download_file/openapi.json.tpl
@@ -1,0 +1,43 @@
+{
+    "openapi": "3.0.1",
+    "info": {
+        "title": "RTD Sender ADE ACK Files Download",
+        "description": "API to download Sender ADE Ack Files",
+        "version": "1.0"
+    }, 
+    "servers": [{
+        "url": "${host}"
+    }],
+    "paths": {
+        "/*": {
+            "get": {
+                "summary": "GET BlobURI",
+                "operationId": "getBlob",
+                "responses": {
+                    "200": {
+                        "description": null
+                    }
+                }
+            }
+        }
+    },
+    "components": {
+        "securitySchemes": {
+            "apiKeyHeader": {
+                "type": "apiKey",
+                "name": "Ocp-Apim-Subscription-Key",
+                "in": "header"
+            },
+            "apiKeyQuery": {
+                "type": "apiKey",
+                "name": "subscription-key",
+                "in": "query"
+            }
+        }
+    },
+    "security": [{
+        "apiKeyHeader": []
+    }, {
+        "apiKeyQuery": []
+    }]
+}

--- a/src/api_tae.tf
+++ b/src/api_tae.tf
@@ -1,0 +1,34 @@
+## RTD CSV Transaction Decrypted API ##
+
+locals {
+  rtd_senderack_download_file_uri = format("https://%s/%s", azurerm_private_endpoint.blob_storage_pe.private_dns_zone_configs[0].record_sets[0].fqdn, azurerm_storage_container.sender_ade_ack[0].name)
+}
+
+module "rtd_senderack_download_file" {
+  count  = var.enable.tae.api ? 1 : 0
+  source = "git::https://github.com/pagopa/azurerm.git//api_management_api?ref=v2.18.3"
+
+  name                = format("%s-senderack-download", var.env_short)
+  api_management_name = module.apim.name
+  resource_group_name = azurerm_resource_group.rg_api.name
+
+  description  = "API to download Sender ADE Ack Files"
+  display_name = "RTD Sender ADE ACK Files Download"
+  path         = "ade"
+  protocols    = ["https"]
+
+  service_url = local.rtd_senderack_download_file_uri
+
+  content_format = "openapi"
+  content_value = templatefile("./api/rtd_senderack_download_file/openapi.json.tpl", {
+    host = local.rtd_senderack_download_file_uri
+  })
+
+  subscription_required = true
+
+  xml_content = file("./api/rtd_senderack_download_file/azureblob_policy.xml")
+
+  product_ids = [module.rtd_api_product.product_id]
+
+  api_operation_policies = []
+}


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
This PR adds an API to download the sender ade ack files from a blob storage container by filename.

### List of changes

<!--- Describe your changes in detail -->
- Add new api with policy and swagger

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->
The batch service must download the sender ade ack files. The filename list is retrieved from `/rtd/file-register/sender-ade-ack` and downloaded with the new api `/ade/{filename}`.

### Type of changes

- [X] Add new resources
- [ ] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [X] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [X] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
