### PR TITLE
[TAE-52] Enable Mongo DB access from ADF subnet

### DIFF
--- a/src/database.tf
+++ b/src/database.tf
@@ -140,7 +140,7 @@ module "postgres_flexible_server" {
 
 module "cosmosdb_account_mongodb" {
 
-  count = var.cosmos_mongo_db_params.enabled ? 1 : 0
+  count = var.enable.tae.adf ? 1 : 0
 
   source = "git::https://github.com/pagopa/azurerm.git//cosmosdb_account?ref=v2.15.1"
 
@@ -159,7 +159,8 @@ module "cosmosdb_account_mongodb" {
   is_virtual_network_filter_enabled = var.cosmos_mongo_db_params.is_virtual_network_filter_enabled
 
   allowed_virtual_network_subnet_ids = [
-    module.k8s_snet.id
+    module.k8s_snet.id,
+    module.adf_snet[count.index].id
   ]
 
   consistency_policy               = var.cosmos_mongo_db_params.consistency_policy

--- a/src/network.tf
+++ b/src/network.tf
@@ -154,6 +154,10 @@ module "adf_snet" {
   resource_group_name                            = azurerm_resource_group.rg_vnet.name
   virtual_network_name                           = module.vnet.name
   enforce_private_link_endpoint_network_policies = true
+
+  service_endpoints = [
+    "Microsoft.AzureCosmosDB",
+  ]
 }
 
 ## Peering between the vnet(main) and integration vnet 


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

This PR proposes to allow access to Mongo DB from ADF subnet

### List of changes

<!--- Describe your changes in detail -->

- Modify the list of MongoDb allowed subnets to include ADF subnet

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

In order to create an ADF pipeline, the Linked Services should be able to access sources and sinks. MongoDB can be both a source and a sink so ADF should be allowed to access it.

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
