### PR TITLE
[RTD-135] API to test rtd api key

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -85,6 +85,7 @@
 | <a name="module_rtd_fake_abi_to_fiscal_code"></a> [rtd\_fake\_abi\_to\_fiscal\_code](#module\_rtd\_fake\_abi\_to\_fiscal\_code) | git::https://github.com/pagopa/azurerm.git//api_management_api | v2.16.0 |
 | <a name="module_rtd_payment_instrument"></a> [rtd\_payment\_instrument](#module\_rtd\_payment\_instrument) | git::https://github.com/pagopa/azurerm.git//api_management_api | v1.0.16 |
 | <a name="module_rtd_payment_instrument_manager"></a> [rtd\_payment\_instrument\_manager](#module\_rtd\_payment\_instrument\_manager) | git::https://github.com/pagopa/azurerm.git//api_management_api | v1.0.16 |
+| <a name="module_rtd_sender_api_key_check"></a> [rtd\_sender\_api\_key\_check](#module\_rtd\_sender\_api\_key\_check) | git::https://github.com/pagopa/azurerm.git//api_management_api | v2.18.4 |
 | <a name="module_rtd_sender_mauth_check"></a> [rtd\_sender\_mauth\_check](#module\_rtd\_sender\_mauth\_check) | git::https://github.com/pagopa/azurerm.git//api_management_api | v2.18.4 |
 | <a name="module_rtd_senderack_download_file"></a> [rtd\_senderack\_download\_file](#module\_rtd\_senderack\_download\_file) | git::https://github.com/pagopa/azurerm.git//api_management_api | v2.18.3 |
 | <a name="module_rtd_senderadeack_filename_list"></a> [rtd\_senderadeack\_filename\_list](#module\_rtd\_senderadeack\_filename\_list) | git::https://github.com/pagopa/azurerm.git//api_management_api | v2.16.0 |

--- a/src/api/rtd_sender_api_key_check/openapi.yml
+++ b/src/api/rtd_sender_api_key_check/openapi.yml
@@ -1,0 +1,16 @@
+openapi: 3.0.0
+info:
+  title: RTD API to Check API Key
+  description: RTD API to check RTD product API Key validity
+  version: 0.0.1
+servers:
+- url: https://httpbin.org
+paths:
+  /check:
+    get:
+      responses:
+        200:
+          description: Check API Key
+          content:
+            application/json: {}
+

--- a/src/api/rtd_sender_api_key_check/policy.xml
+++ b/src/api/rtd_sender_api_key_check/policy.xml
@@ -1,0 +1,15 @@
+<policies>
+  <inbound>
+    <base />
+    <mock-response status-code='200' content-type='application/json'/>
+  </inbound>
+  <backend>
+    <base />
+  </backend>
+  <outbound>
+    <base />
+  </outbound>
+  <on-error>
+    <base />
+  </on-error>
+</policies>

--- a/src/api_rtd.tf
+++ b/src/api_rtd.tf
@@ -319,6 +319,36 @@ module "rtd_sender_mauth_check" {
   api_operation_policies = []
 }
 
+module "rtd_sender_api_key_check" {
+
+  count = var.enable.rtd.batch_service_api ? 1 : 0
+
+  source = "git::https://github.com/pagopa/azurerm.git//api_management_api?ref=v2.18.4"
+
+  name                = format("%s-rtd-sender-api-key-check", var.env_short)
+  api_management_name = module.apim.name
+  resource_group_name = azurerm_resource_group.rg_api.name
+
+
+  description  = "RTD API to check RTD product API Key validity"
+  display_name = "RTD API to Check API Key"
+  path         = "rtd/api-key"
+  protocols    = ["https"]
+
+  service_url = ""
+
+  # Mandatory field when api definition format is openapi
+  content_format = "openapi"
+  content_value  = file("./api/rtd_sender_api_key_check/openapi.yml")
+
+  xml_content = file("./api/rtd_sender_api_key_check/policy.xml")
+
+  product_ids           = [module.rtd_api_product.product_id]
+  subscription_required = true
+
+  api_operation_policies = []
+}
+
 # 
 # SUBSCRIPTIONS FOR INTERNAL USERS
 #


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
This PR proposes the addition of an API that allows senders to test their RTD API validity.
### List of changes
<!--- Describe your changes in detail -->
- add the new module rtd_sender_api_key_check that model the behaviour of the API Key check endpoint

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->
As second step of sender onboarding, we want to provide an endpoint that allows the client to test for its API Key validity.
The module uses the feature flag for batch service endpoints.
### Type of changes

- [x] Add new resources
- [ ] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
