### PR TITLE
[TAE-82] Add dataset for wrong fiscal codes

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -136,6 +136,7 @@
 | [azurerm_data_factory_custom_dataset.destination_aggregate](https://registry.terraform.io/providers/hashicorp/azurerm/2.99.0/docs/resources/data_factory_custom_dataset) | resource |
 | [azurerm_data_factory_custom_dataset.source_ack](https://registry.terraform.io/providers/hashicorp/azurerm/2.99.0/docs/resources/data_factory_custom_dataset) | resource |
 | [azurerm_data_factory_custom_dataset.source_aggregate](https://registry.terraform.io/providers/hashicorp/azurerm/2.99.0/docs/resources/data_factory_custom_dataset) | resource |
+| [azurerm_data_factory_custom_dataset.wrong_fiscal_codes](https://registry.terraform.io/providers/hashicorp/azurerm/2.99.0/docs/resources/data_factory_custom_dataset) | resource |
 | [azurerm_data_factory_linked_service_azure_blob_storage.tae_adf_sa_linked_service](https://registry.terraform.io/providers/hashicorp/azurerm/2.99.0/docs/resources/data_factory_linked_service_azure_blob_storage) | resource |
 | [azurerm_data_factory_linked_service_azure_blob_storage.tae_adf_sftp_linked_service](https://registry.terraform.io/providers/hashicorp/azurerm/2.99.0/docs/resources/data_factory_linked_service_azure_blob_storage) | resource |
 | [azurerm_data_factory_linked_service_cosmosdb_mongoapi.tae_adf_mongo_linked_service](https://registry.terraform.io/providers/hashicorp/azurerm/2.99.0/docs/resources/data_factory_linked_service_cosmosdb_mongoapi) | resource |

--- a/src/tae_datasets.tf
+++ b/src/tae_datasets.tf
@@ -347,7 +347,6 @@ resource "azurerm_data_factory_custom_dataset" "wrong_fiscal_codes" {
     "location": {
       "type": "AzureBlobStorageLocation",
       "container": "sender-ade-ack",
-      "folderPath": "",
       "fileName": {
         "value": "@dataset().file",
         "type": "Expression"

--- a/src/tae_datasets.tf
+++ b/src/tae_datasets.tf
@@ -329,3 +329,57 @@ resource "azurerm_data_factory_custom_dataset" "source_ack" {
   ]
   JSON
 }
+
+resource "azurerm_data_factory_custom_dataset" "wrong_fiscal_codes" {
+
+  count = var.enable.tae.adf ? 1 : 0
+
+  name            = "WrongFiscalCodes"
+  data_factory_id = data.azurerm_data_factory.tae_adf[count.index].id
+  type            = "DelimitedText"
+
+  linked_service {
+    name = azurerm_data_factory_linked_service_azure_blob_storage.tae_adf_sa_linked_service[count.index].name
+  }
+
+  type_properties_json = <<JSON
+  {
+    "location": {
+      "type": "AzureBlobStorageLocation",
+      "container": "sender-ade-ack",
+      "folderPath": "",
+      "fileName": {
+        "value": "@dataset().file",
+        "type": "Expression"
+      }
+    },
+    "columnDelimiter": ";",
+    "encodingName": "UTF-8",
+    "quoteChar": ""
+  }     
+  JSON
+
+  description = "Wrong Fiscal Codes to be Returned to Senders"
+  annotations = ["WrongFiscalCodes"]
+
+  parameters = {
+    file = "myFile"
+  }
+
+  schema_json = <<JSON
+  [
+    {
+      "name": "senderCode",
+      "type": "String"
+    },
+    {
+      "name": "acquirerId",
+      "type": "String"
+    },
+    {
+      "name": "fiscalCode",
+      "type": "String"
+    }
+  ]
+  JSON
+}


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
This PR proposes to add a new dataset to represent wrong fiscal codes

### List of changes

<!--- Describe your changes in detail -->
- New dataset for wrong fiscal codes

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->
This dataset solves the problem of representing worng fiscal codes to be sent to senders

### Type of changes

- [x] Add new resources
- [ ] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
