### PR TITLE
[TAR-97] Add mongo connection URI to secrets

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -160,6 +160,7 @@
 | [azurerm_key_vault_secret.cstar_blobstorage_key](https://registry.terraform.io/providers/hashicorp/azurerm/2.99.0/docs/resources/key_vault_secret) | resource |
 | [azurerm_key_vault_secret.event_hub_keys](https://registry.terraform.io/providers/hashicorp/azurerm/2.99.0/docs/resources/key_vault_secret) | resource |
 | [azurerm_key_vault_secret.event_hub_keys_fa_01](https://registry.terraform.io/providers/hashicorp/azurerm/2.99.0/docs/resources/key_vault_secret) | resource |
+| [azurerm_key_vault_secret.mongo_db_connection_uri](https://registry.terraform.io/providers/hashicorp/azurerm/2.99.0/docs/resources/key_vault_secret) | resource |
 | [azurerm_key_vault_secret.rtd_internal_api_product_subscription_key](https://registry.terraform.io/providers/hashicorp/azurerm/2.99.0/docs/resources/key_vault_secret) | resource |
 | [azurerm_log_analytics_workspace.log_analytics_workspace](https://registry.terraform.io/providers/hashicorp/azurerm/2.99.0/docs/resources/log_analytics_workspace) | resource |
 | [azurerm_monitor_action_group.email](https://registry.terraform.io/providers/hashicorp/azurerm/2.99.0/docs/resources/monitor_action_group) | resource |

--- a/src/database.tf
+++ b/src/database.tf
@@ -193,3 +193,12 @@ resource "azurerm_cosmosdb_mongo_database" "rtd_db" {
     }
   }
 }
+
+resource "azurerm_key_vault_secret" "mongo_db_connection_uri" {
+
+  count = var.enable.rtd.file_register ? 1 : 0
+
+  name         = "mongo-db-connection-uri"
+  value        = module.cosmosdb_account_mongodb[count.index].connection_strings[0]
+  key_vault_id = module.key_vault.id
+}

--- a/src/k8s/rtd_secrets.tf
+++ b/src/k8s/rtd_secrets.tf
@@ -134,7 +134,7 @@ resource "kubernetes_secret" "mongo_db_credentials" {
   }
 
   data = {
-    MONGODB_KEY = module.key_vault_secrets_query.values["mongo-db-key"].value
+    MONGODB_CONNECTION_URI = module.key_vault_secrets_query.values["mongo-db-connection-uri"].value
   }
 
   type = "Opaque"

--- a/src/k8s/scripts/setup.sh
+++ b/src/k8s/scripts/setup.sh
@@ -27,6 +27,8 @@ if [ ! -d "${WORKDIR}/subscriptions/${SUBSCRIPTION}" ]; then
     exit 1
 fi
 
+echo "Please make sure to be under VPN"
+
 az account set -s "${SUBSCRIPTION}"
 source ./subscriptions/${SUBSCRIPTION}/conf
 

--- a/src/k8s/subscriptions/DEV-CSTAR/terraform.tfvars
+++ b/src/k8s/subscriptions/DEV-CSTAR/terraform.tfvars
@@ -455,7 +455,7 @@ secrets_to_be_read_from_kv = [
   "cstarblobstorage-private-key",
   "cstarblobstorage-private-key-passphrase",
   "rtd-internal-api-product-subscription-key",
-  "mongo-db-key"
+  "mongo-db-connection-uri"
 ]
 
 enable = {


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
This PR proposes to add MongoDB connection URI to secrets.

### List of changes

<!--- Describe your changes in detail -->
- add MongoDB connection URI to secrets (mongo-credentials)
- remove MongoDB key from secrets
### Motivation and context

<!--- Why is this change required? What problem does it solve? -->
This change allows file register to connect to MongoDB.
### Type of changes

- [x] Add new resources
- [x] Update configuration to existing resources
- [x] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
