### PR TITLE
[TAE-88] Hash Sender Code for container name

### DIFF
--- a/src/api/rtd_csv_transaction/create-sas-token-policy.xml
+++ b/src/api/rtd_csv_transaction/create-sas-token-policy.xml
@@ -262,9 +262,7 @@
             <set-body>@{
                 return new JObject(
                     new JProperty("sas", context.Variables["sas"]),
-                    new JProperty("authorizedContainer", context.Variables["containerName"]),
-                    new JProperty("senderCode", context.Variables["senderCode"]),
-                    new JProperty("senderCodeHash", context.Variables["senderCodeHash"])
+                    new JProperty("authorizedContainer", context.Variables["containerName"])
                 ).ToString();
              }
             </set-body>

--- a/src/api/rtd_csv_transaction/create-sas-token-policy.xml
+++ b/src/api/rtd_csv_transaction/create-sas-token-policy.xml
@@ -36,7 +36,7 @@
         }"
         />
 
-        <send-request mode="new" response-variable-name="senderCode" timeout="60" ignore-error="true">
+        <send-request mode="new" response-variable-name="senderCodeResponse" timeout="60" ignore-error="true">
             <set-url>@("http://${rtd-ingress-ip}/rtdmssenderauth/sender-code?internalId="+(string)context.Variables["keyHash"])</set-url>
             <set-method>GET</set-method>
         </send-request>
@@ -63,9 +63,10 @@
 
             See: https://stackoverflow.com/questions/38474362/get-a-file-sha256-hash-code-and-checksum
         -->
+        <set-variable name="senderCode" value="@((IResponse)context.Variables["senderCodeResponse"]).Body.As<string>()"/>
         <set-variable name="senderCodeHash" value="@{
                 System.Security.Cryptography.SHA256 hasher = System.Security.Cryptography.SHA256.Create();
-                return BitConverter.ToString(hasher.ComputeHash(System.Text.Encoding.UTF8.GetBytes(context.Request.Headers.GetValueOrDefault("senderCode", "")))).Replace("-", "").ToLowerInvariant();
+                return BitConverter.ToString(hasher.ComputeHash(System.Text.Encoding.UTF8.GetBytes(context.Variables.GetValueOrDefault("senderCode", "")))).Replace("-", "").ToLowerInvariant();
             }"
         />
         

--- a/src/api/rtd_csv_transaction/create-sas-token-policy.xml
+++ b/src/api/rtd_csv_transaction/create-sas-token-policy.xml
@@ -16,7 +16,7 @@
         <!--
             This policy grants temporary upload grants to clients by issuing SAS tokens.
 
-            Access is limited to a single container derived from client's APIM Subscription Key.
+            Access is limited to a single container derived from client's sender code.
             The container, if not already present, is created on the fly from the policy itself.
         -->
 
@@ -28,16 +28,28 @@
 
         <!-- SAS Token variables -->
         <set-variable name="sasTokenExpiresInMinutes" value="60" />
-        
+
+        <!-- Translate from API Key to Sender Code -->
+        <set-variable name="keyHash" value="@{
+                    System.Security.Cryptography.SHA256 hasher = System.Security.Cryptography.SHA256.Create();
+                    return BitConverter.ToString(hasher.ComputeHash(System.Text.Encoding.UTF8.GetBytes(context.Request.Headers.GetValueOrDefault("Ocp-Apim-Subscription-Key","")))).Replace("-", "").ToLowerInvariant();
+        }"
+        />
+
+        <send-request mode="new" response-variable-name="senderCode" timeout="60" ignore-error="true">
+            <set-url>@("http://${rtd-ingress-ip}/rtdmssenderauth/sender-code?internalId="+(string)context.Variables["keyHash"])</set-url>
+            <set-method>GET</set-method>
+        </send-request>
+
         <!--
-            START - Derive the client's own container from the APIM Subscription Key
+            START - Derive the client's own container from the sender code
 
             The container name is computed by combining a static prefix (containerPrefix) and the first 44 characters
-            of the SHA256 checksum of the APIM Subscription Key.
+            of the SHA256 checksum of the sender code.
         -->
         
         <!--
-            The following block computes the SHA256 checksum of the API Subscription Key using C# cryptographic library.
+            The following block computes the SHA256 checksum of the Sender Code using C# cryptographic library.
 
             To compute the same hash in Python (tested with Python 3.9.9):
 
@@ -47,20 +59,20 @@
 
             To compute the same hash with Coreutils sha256sum from command line:
 
-            echo -n <APIM_SUBSCRIPTION_KEY> | sha256sum
+            echo -n <Sender Code> | sha256sum
 
             See: https://stackoverflow.com/questions/38474362/get-a-file-sha256-hash-code-and-checksum
         -->
-        <set-variable name="apimSubscriptionKeyHash" value="@{
+        <set-variable name="senderCodeHash" value="@{
                 System.Security.Cryptography.SHA256 hasher = System.Security.Cryptography.SHA256.Create();
-                return BitConverter.ToString(hasher.ComputeHash(System.Text.Encoding.UTF8.GetBytes(context.Request.Headers.GetValueOrDefault("Ocp-Apim-Subscription-Key", "")))).Replace("-", "").ToLowerInvariant();
+                return BitConverter.ToString(hasher.ComputeHash(System.Text.Encoding.UTF8.GetBytes(context.Request.Headers.GetValueOrDefault("senderCode", "")))).Replace("-", "").ToLowerInvariant();
             }"
         />
         
         <set-variable name="containerName" value="@{
             return string.Format("{0}-{1}",
                 (string)context.Variables["containerPrefix"],
-                ((string)context.Variables["apimSubscriptionKeyHash"]).Substring(0, 44));
+                ((string)context.Variables["senderCodeHash"]).Substring(0, 44));
             }"
         />
         <!--

--- a/src/api/rtd_csv_transaction/create-sas-token-policy.xml
+++ b/src/api/rtd_csv_transaction/create-sas-token-policy.xml
@@ -63,7 +63,8 @@
 
             See: https://stackoverflow.com/questions/38474362/get-a-file-sha256-hash-code-and-checksum
         -->
-        <set-variable name="senderCode" value="@((IResponse)context.Variables["senderCodeResponse"]).Body.As<string>()"/>
+        <set-variable name="senderCode" value="@(((IResponse)context.Variables["senderCodeResponse"]).Body.As<string>())"/>
+
         <set-variable name="senderCodeHash" value="@{
                 System.Security.Cryptography.SHA256 hasher = System.Security.Cryptography.SHA256.Create();
                 return BitConverter.ToString(hasher.ComputeHash(System.Text.Encoding.UTF8.GetBytes(context.Variables.GetValueOrDefault("senderCode", "")))).Replace("-", "").ToLowerInvariant();

--- a/src/api/rtd_csv_transaction/create-sas-token-policy.xml
+++ b/src/api/rtd_csv_transaction/create-sas-token-policy.xml
@@ -260,7 +260,9 @@
             <set-body>@{
                 return new JObject(
                     new JProperty("sas", context.Variables["sas"]),
-                    new JProperty("authorizedContainer", context.Variables["containerName"])
+                    new JProperty("authorizedContainer", context.Variables["containerName"]),
+                    new JProperty("senderCode", context.Variables["senderCode"]),
+                    new JProperty("senderCodeHash", context.Variables["senderCodeHash"])
                 ).ToString();
              }
             </set-body>

--- a/src/api_rtd.tf
+++ b/src/api_rtd.tf
@@ -209,7 +209,7 @@ module "rtd_csv_transaction" {
         blob-storage-account-name     = module.cstarblobstorage.name,
         blob-storage-private-fqdn     = azurerm_private_endpoint.blob_storage_pe.private_dns_zone_configs[0].record_sets[0].fqdn,
         blob-storage-container-prefix = "ade-transactions",
-        rtd-ingress-ip = var.reverse_proxy_ip
+        rtd-ingress-ip                = var.reverse_proxy_ip
       })
     },
     {
@@ -219,7 +219,7 @@ module "rtd_csv_transaction" {
         blob-storage-account-name     = module.cstarblobstorage.name,
         blob-storage-private-fqdn     = azurerm_private_endpoint.blob_storage_pe.private_dns_zone_configs[0].record_sets[0].fqdn,
         blob-storage-container-prefix = "rtd-transactions",
-        rtd-ingress-ip = var.reverse_proxy_ip
+        rtd-ingress-ip                = var.reverse_proxy_ip
       })
     },
     {

--- a/src/api_rtd.tf
+++ b/src/api_rtd.tf
@@ -204,7 +204,7 @@ module "rtd_csv_transaction" {
   api_operation_policies = [
     {
       operation_id = "createAdeSasToken",
-      xml_content = templatefile("./api/rtd_csv_transaction/create-sas-token-policy.xml.tpl", {
+      xml_content = templatefile("./api/rtd_csv_transaction/create-sas-token-policy.xml", {
         blob-storage-access-key       = module.cstarblobstorage.primary_access_key,
         blob-storage-account-name     = module.cstarblobstorage.name,
         blob-storage-private-fqdn     = azurerm_private_endpoint.blob_storage_pe.private_dns_zone_configs[0].record_sets[0].fqdn,
@@ -214,7 +214,7 @@ module "rtd_csv_transaction" {
     },
     {
       operation_id = "createRtdSasToken",
-      xml_content = templatefile("./api/rtd_csv_transaction/create-sas-token-policy.xml.tpl", {
+      xml_content = templatefile("./api/rtd_csv_transaction/create-sas-token-policy.xml", {
         blob-storage-access-key       = module.cstarblobstorage.primary_access_key,
         blob-storage-account-name     = module.cstarblobstorage.name,
         blob-storage-private-fqdn     = azurerm_private_endpoint.blob_storage_pe.private_dns_zone_configs[0].record_sets[0].fqdn,

--- a/src/api_rtd.tf
+++ b/src/api_rtd.tf
@@ -208,7 +208,8 @@ module "rtd_csv_transaction" {
         blob-storage-access-key       = module.cstarblobstorage.primary_access_key,
         blob-storage-account-name     = module.cstarblobstorage.name,
         blob-storage-private-fqdn     = azurerm_private_endpoint.blob_storage_pe.private_dns_zone_configs[0].record_sets[0].fqdn,
-        blob-storage-container-prefix = "ade-transactions"
+        blob-storage-container-prefix = "ade-transactions",
+        rtd-ingress-ip = var.reverse_proxy_ip
       })
     },
     {
@@ -217,7 +218,8 @@ module "rtd_csv_transaction" {
         blob-storage-access-key       = module.cstarblobstorage.primary_access_key,
         blob-storage-account-name     = module.cstarblobstorage.name,
         blob-storage-private-fqdn     = azurerm_private_endpoint.blob_storage_pe.private_dns_zone_configs[0].record_sets[0].fqdn,
-        blob-storage-container-prefix = "rtd-transactions"
+        blob-storage-container-prefix = "rtd-transactions",
+        rtd-ingress-ip = var.reverse_proxy_ip
       })
     },
     {


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes
- change the endpoint policy to translate the api key in sender code
- modify the naming of the container based on the hash of the sender code
<!--- Describe your changes in detail -->

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->
This change allows us to refer to a sender's container with the hash of the sender code.
This is easier compared to the hash of the api key.
### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
Targets:
- module.rtd_csv_transaction[0].azurerm_api_management_api_operation_policy.api_operation_policy
---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
