### PR TITLE
[TAE-172] Migrate cosmos in prod

### DIFF
--- a/src/core/env/prod/terraform.tfvars
+++ b/src/core/env/prod/terraform.tfvars
@@ -347,25 +347,25 @@ pgres_flex_params = {
 
 dns_zone_prefix = "cstar"
 cosmos_mongo_db_params = {
-  enabled      = false
+  enabled      = true
   kind         = "MongoDB"
   capabilities = ["EnableMongo"]
   offer_type   = "Standard"
   consistency_policy = {
-    consistency_level       = "BoundedStaleness"
-    max_interval_in_seconds = 300
-    max_staleness_prefix    = 100000
+    consistency_level       = "Strong"
+    max_interval_in_seconds = 5
+    max_staleness_prefix    = 100
   }
-  server_version                   = "4.0"
-  main_geo_location_zone_redundant = false
-  enable_free_tier                 = true
+  server_version                   = "4.2"
+  main_geo_location_zone_redundant = true
+  enable_free_tier                 = false
 
   private_endpoint_enabled      = true
   public_network_access_enabled = false
   additional_geo_locations = [{
     location          = "northeurope"
     failover_priority = 1
-    zone_redundant    = false
+    zone_redundant    = true
   }]
 
   is_virtual_network_filter_enabled = true

--- a/src/domains/tae-common/env/prod/backend.ini
+++ b/src/domains/tae-common/env/prod/backend.ini
@@ -1,0 +1,1 @@
+subscription=PROD-CSTAR

--- a/src/domains/tae-common/env/prod/backend.tfvars
+++ b/src/domains/tae-common/env/prod/backend.tfvars
@@ -1,0 +1,4 @@
+resource_group_name  = "io-infra-rg"
+storage_account_name = "cstarinfrastterraform"
+container_name       = "azurermstate"
+key                  = "domain-tae-common.terraform.tfstate"

--- a/src/domains/tae-common/env/prod/terraform.tfvars
+++ b/src/domains/tae-common/env/prod/terraform.tfvars
@@ -1,0 +1,70 @@
+prefix         = "cstar"
+env_short      = "p"
+env            = "prod"
+domain         = "tae"
+location       = "westeurope"
+location_short = "weu"
+instance       = "prod"
+
+tags = {
+  CreatedBy   = "Terraform"
+  Environment = "Prod"
+  Owner       = "CSTAR"
+  Source      = "https://github.com/pagopa/cstar-infrastructure"
+  CostCenter  = "TS310 - PAGAMENTI & SERVIZI"
+  Application = "TAE"
+}
+
+lock_enable = true
+
+terraform_remote_state_core = {
+  resource_group_name  = "io-infra-rg"
+  storage_account_name = "cstarinfrastterraform"
+  container_name       = "azureadstate"
+  key                  = "prod.terraform.tfstate"
+}
+
+cosmos_dbms_params = {
+  enabled      = true
+  kind         = "GlobalDocumentDB"
+  capabilities = []
+  offer_type   = "Standard"
+  consistency_policy = {
+    consistency_level       = "Strong"
+    max_interval_in_seconds = 5 # Standard value, should not be set
+    max_staleness_prefix    = 100 # standard value, should not be set
+  }
+  server_version                   = null
+  main_geo_location_zone_redundant = true
+  enable_free_tier                 = false
+
+  private_endpoint_enabled          = true
+  public_network_access_enabled     = false
+  additional_geo_locations          = []
+  is_virtual_network_filter_enabled = true
+
+  backup_continuous_enabled = true
+}
+
+cosmos_db_aggregates_params = {
+  enable_serverless  = false
+  enable_autoscaling = true
+  max_throughput     = 10000
+  throughput         = 1000
+}
+
+### External resources
+
+# Monitoring
+monitor_resource_group_name                 = "cstar-p-monitor-rg"
+log_analytics_workspace_name                = "cstar-p-law"
+log_analytics_workspace_resource_group_name = "cstar-p-monitor-rg"
+
+
+acquirer_storage_params = {
+  analytics_workspace_enabled = true
+}
+
+sftp_storage_params = {
+  analytics_workspace_enabled = true
+}

--- a/src/domains/tae-common/env/prod/terraform.tfvars
+++ b/src/domains/tae-common/env/prod/terraform.tfvars
@@ -31,7 +31,7 @@ cosmos_dbms_params = {
   offer_type   = "Standard"
   consistency_policy = {
     consistency_level       = "Strong"
-    max_interval_in_seconds = 5 # Standard value, should not be set
+    max_interval_in_seconds = 5   # Standard value, should not be set
     max_staleness_prefix    = 100 # standard value, should not be set
   }
   server_version                   = null


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
This PR proposes to migrate comsos (both mongo and sql api) to production.
Cosmos SQL API supports Data Factories. Cosmos Mongo API supports TAE/RTD microservices
### List of changes

<!--- Describe your changes in detail -->
- New instance of Cosmos DB SQL API
- New Instance of Cosmos DB MONGO API
- Cosmos subnets
- Private endpoints subnet

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->
These changes are required to support TAE in production

### Type of changes

- [ ] Add new resources
- [ ] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
