### PR TITLE
[RTD-432] change policy in sftp-retrieve to get ade ack from out cont…

### DIFF
--- a/src/core/api/rtd_deposited_file_check/azureblob_policy.xml
+++ b/src/core/api/rtd_deposited_file_check/azureblob_policy.xml
@@ -4,22 +4,45 @@
     <inbound>
       <base />
       <authentication-managed-identity resource="https://storage.azure.com/" output-token-variable-name="msi-access-token" ignore-error="false" />
+
+      <set-variable name="fileName" value="@(context.Request.MatchedParameters["fileName"])" />
+
+      <send-request mode="new" response-variable-name="ade-in-response" timeout="60" ignore-error="true">
+        <set-url>@("${ade-in}"+context.Variables["fileName"])</set-url>
+        <set-method>GET</set-method>
+        <set-header name="X-Ms-Version" exists-action="override">
+          <value>2021-06-08</value>
+        </set-header>
+        <set-header name="Authorization" exists-action="override">
+          <value>@("Bearer " + (string)context.Variables["msi-access-token"])</value>
+        </set-header>
+      </send-request>
+
+      <choose>
+        <when condition="@(((IResponse)context.Variables["ade-in-response"]).StatusCode == 200)" >
+          <return-response response-variable-name="ade-in-response" >
+          </return-response>
+        </when>
+        <otherwise>
+          <set-backend-service base-url="${ade-out}" />
+          <rewrite-uri template="@(context.Variables["fileName"]+".OK.OK")" />
+        </otherwise>
+      </choose>
+
       <set-header name="X-Ms-Version" exists-action="override">
         <value>2021-06-08</value>
       </set-header>
- 
       <set-header name="Authorization" exists-action="override">
         <value>@("Bearer " + (string)context.Variables["msi-access-token"])</value>
       </set-header>
-      
+
     </inbound>
     <backend>
         <base />
     </backend>
     <outbound>
         <base />
-        <set-header name="ETag" exists-action="delete" />
-        <set-header name="x-ms-request-id" exists-action="delete" />
+
         <set-header name="x-ms-version" exists-action="delete" />
         <set-header name="x-ms-resource-type" exists-action="delete" />
         <set-header name="x-ms-creation-time" exists-action="delete" />

--- a/src/core/api/rtd_deposited_file_check/openapi.yml
+++ b/src/core/api/rtd_deposited_file_check/openapi.yml
@@ -6,13 +6,20 @@ info:
 servers:
   - url: ${host}
 paths:
-  /*:
+  /{fileName}:
     get:
       summary: GET BlobURI
       operationId: getBlob
       responses:
         "200":
           description: "Ok"
+      parameters:
+        - name: fileName
+          in: path
+          description: filename to download
+          required: true
+          schema:
+            type: string
 components:
   securitySchemes:
     apiKeyHeader:

--- a/src/core/api_rtd.tf
+++ b/src/core/api_rtd.tf
@@ -430,11 +430,12 @@ module "rtd_deposited_file_check" {
 
   # Mandatory field when api definition format is openapi
   content_format = "openapi"
-  content_value = templatefile("./api/rtd_deposited_file_check/openapi.yml", {
-    host = format("https://cstar%ssftp.blob.core.windows.net/ade/in/", var.env_short)
-  })
+  content_value  = file("./api/rtd_deposited_file_check/openapi.yml")
 
-  xml_content = file("./api/rtd_deposited_file_check/azureblob_policy.xml")
+  xml_content = templatefile("./api/rtd_deposited_file_check/azureblob_policy.xml", {
+    ade-in  = format("https://cstar%ssftp.blob.core.windows.net/ade/in/", var.env_short),
+    ade-out = format("https://cstar%ssftp.blob.core.windows.net/ade/out/", var.env_short)
+  })
 
   product_ids           = [module.rtd_api_product.product_id]
   subscription_required = true


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
This PR proposes to change the sftp-retrieve policy to check the availability of ade ack file in `ade/in` container and `ade/out` container.

### List of changes

<!--- Describe your changes in detail -->
- Change apim policy

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->
The acquirer must check the equality of uploaded file with the one sent to ADE. ADE may move the file from ade/in to ade/out therefore it is required to check on two different containers.

### Type of changes

- [ ] Add new resources
- [X] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [X] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
