### PR TITLE
[RTD-433] increase the decrypter consumer timeout

### DIFF
--- a/src/k8s/rtd_configmaps.tf
+++ b/src/k8s/rtd_configmaps.tf
@@ -65,7 +65,7 @@ resource "kubernetes_config_map" "rtddecrypter" {
     , ".")
     SPLITTER_LINE_THRESHOLD = 250000,
     ENABLE_CHUNK_UPLOAD     = false,
-    CONSUMER_TIMEOUT_MS     = 600000 # 10 minutes
+    CONSUMER_TIMEOUT_MS     = 7200000 # 2 hours
     },
   var.configmaps_rtddecrypter)
 }


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
This PR proposes to increase the decrypter consumer timeout from 10 minutes to 2 hours.

### List of changes

<!--- Describe your changes in detail -->
- Changed config map of micro service decrypter

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->
In order to avoid the consumer timeout during the file elaboration it is required to increase the `max.poll.interval.ms` through the config map of micro service decrypter. 

### Type of changes

- [ ] Add new resources
- [X] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [X] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [X] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
