### PR TITLE
[RTD-438] add tmp container on blob storage

### DIFF
--- a/src/core/README.md
+++ b/src/core/README.md
@@ -226,6 +226,7 @@
 | [azurerm_storage_container.psql_state](https://registry.terraform.io/providers/hashicorp/azurerm/2.99.0/docs/resources/storage_container) | resource |
 | [azurerm_storage_container.rtd_transactions_decrypted](https://registry.terraform.io/providers/hashicorp/azurerm/2.99.0/docs/resources/storage_container) | resource |
 | [azurerm_storage_container.sender_ade_ack](https://registry.terraform.io/providers/hashicorp/azurerm/2.99.0/docs/resources/storage_container) | resource |
+| [azurerm_storage_container.tmp_container](https://registry.terraform.io/providers/hashicorp/azurerm/2.99.0/docs/resources/storage_container) | resource |
 | [azurerm_storage_management_policy.backups](https://registry.terraform.io/providers/hashicorp/azurerm/2.99.0/docs/resources/storage_management_policy) | resource |
 | [azurerm_storage_share.dns_forwarder](https://registry.terraform.io/providers/hashicorp/azurerm/2.99.0/docs/resources/storage_share) | resource |
 | [azurerm_user_assigned_identity.appgateway](https://registry.terraform.io/providers/hashicorp/azurerm/2.99.0/docs/resources/user_assigned_identity) | resource |

--- a/src/core/tae_storage.tf
+++ b/src/core/tae_storage.tf
@@ -13,3 +13,11 @@ resource "azurerm_storage_container" "sender_ade_ack" {
   storage_account_name  = module.cstarblobstorage.name
   container_access_type = "private"
 }
+
+# Container for the ade ack ingestor pipeline
+resource "azurerm_storage_container" "tmp_container" {
+  count                 = var.enable.tae.blob_containers ? 1 : 0
+  name                  = "tmp"
+  storage_account_name  = module.cstarblobstorage.name
+  container_access_type = "private"
+}


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
This PR proposes to create the container `tmp` in `cstarblobstorage`, which it is utilized by the ade ack ingestor pipeline.

### List of changes

<!--- Describe your changes in detail -->
- Blob storage container creation

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->
The ade ack ingestor pipeline needs a container to temporarily create the ade ack files and then copy though a copyData activity to generate the `blobCreated` event.

### Type of changes

- [X] Add new resources
- [ ] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [X] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [X] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
