### PR TITLE
[RTD-435] Reduce Ack Ingestor Frequency from 4/hour to 1/hour

### DIFF
--- a/src/domains/tae-app/08_pipeline.tf
+++ b/src/domains/tae-app/08_pipeline.tf
@@ -128,8 +128,8 @@ resource "azurerm_data_factory_trigger_schedule" "ade_ack" {
   name            = format("%s-ade-ack-trigger", local.project)
   data_factory_id = data.azurerm_data_factory.datafactory.id
 
-  interval  = 60
-  frequency = "Minute"
+  interval  = var.ack_ingestor_conf.interval
+  frequency = var.ack_ingestor_conf.frequency
   activated = true
   time_zone = "UTC"
 

--- a/src/domains/tae-app/08_pipeline.tf
+++ b/src/domains/tae-app/08_pipeline.tf
@@ -128,7 +128,7 @@ resource "azurerm_data_factory_trigger_schedule" "ade_ack" {
   name            = format("%s-ade-ack-trigger", local.project)
   data_factory_id = data.azurerm_data_factory.datafactory.id
 
-  interval  = 15
+  interval  = 60
   frequency = "Minute"
   activated = true
   time_zone = "UTC"

--- a/src/domains/tae-app/99_variables.tf
+++ b/src/domains/tae-app/99_variables.tf
@@ -127,3 +127,14 @@ variable "dns_zone_internal_prefix" {
   default     = null
   description = "The dns subdomain."
 }
+
+variable "ack_ingestor_conf" {
+  type = object({
+    interval  = number
+    frequency = string
+  })
+  default = {
+    interval  = 15
+    frequency = "Minute"
+  }
+}

--- a/src/domains/tae-app/README.md
+++ b/src/domains/tae-app/README.md
@@ -53,6 +53,7 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_ack_ingestor_conf"></a> [ack\_ingestor\_conf](#input\_ack\_ingestor\_conf) | n/a | <pre>object({<br>    interval  = number<br>    frequency = string<br>  })</pre> | <pre>{<br>  "frequency": "Minute",<br>  "interval": 15<br>}</pre> | no |
 | <a name="input_aks_name"></a> [aks\_name](#input\_aks\_name) | AKS cluster name | `string` | n/a | yes |
 | <a name="input_aks_resource_group_name"></a> [aks\_resource\_group\_name](#input\_aks\_resource\_group\_name) | AKS cluster resource name | `string` | n/a | yes |
 | <a name="input_dns_zone_internal_prefix"></a> [dns\_zone\_internal\_prefix](#input\_dns\_zone\_internal\_prefix) | The dns subdomain. | `string` | `null` | no |

--- a/src/domains/tae-app/env/dev/terraform.tfvars
+++ b/src/domains/tae-app/env/dev/terraform.tfvars
@@ -42,3 +42,9 @@ ingress_load_balancer_ip = "10.11.100.250"
 # 
 external_domain          = "pagopa.it"
 dns_zone_internal_prefix = "internal.dev.cstar"
+
+ack_ingestor_conf = {
+  interval  = 120
+  frequency = "Minute"
+
+}

--- a/src/domains/tae-app/env/prod/terraform.tfvars
+++ b/src/domains/tae-app/env/prod/terraform.tfvars
@@ -44,7 +44,7 @@ external_domain          = "pagopa.it"
 dns_zone_internal_prefix = "internal.prod.cstar"
 
 ack_ingestor_conf = {
-  interval  = 15
+  interval  = 60
   frequency = "Minute"
 
 }

--- a/src/domains/tae-app/env/prod/terraform.tfvars
+++ b/src/domains/tae-app/env/prod/terraform.tfvars
@@ -42,3 +42,9 @@ ingress_load_balancer_ip = "10.11.100.250"
 # 
 external_domain          = "pagopa.it"
 dns_zone_internal_prefix = "internal.prod.cstar"
+
+ack_ingestor_conf = {
+  interval  = 15
+  frequency = "Minute"
+
+}

--- a/src/domains/tae-app/env/uat/terraform.tfvars
+++ b/src/domains/tae-app/env/uat/terraform.tfvars
@@ -42,3 +42,9 @@ ingress_load_balancer_ip = "10.11.100.250"
 # 
 external_domain          = "pagopa.it"
 dns_zone_internal_prefix = "internal.uat.cstar"
+
+ack_ingestor_conf = {
+  interval  = 15
+  frequency = "Minute"
+
+}


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
This PR proposes to reduce the frequency of Ack Ingestor Pipeline to 1/hour
### List of changes

<!--- Describe your changes in detail -->
- For testing purposes, Ack Ingestor frequency was set to 4/hour. In this PR we propose to reduce it to 4/hour

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->
This PR is motivated by the fact that input for ade ack ingestor batch are generated with a frequency of 1 file / hour

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [X] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
