### PR TITLE
[RTD-446] add ICARD to conversion map abi-fiscalCode

### DIFF
--- a/src/core/api/rtd_abi_to_fiscalcode/policy.xml.tpl
+++ b/src/core/api/rtd_abi_to_fiscalcode/policy.xml.tpl
@@ -10,7 +10,8 @@
         return new JObject(
           new JProperty("STPAY", "LU30726739"),
           new JProperty("BPAY1", "04949971008"),
-          new JProperty("SUMUP", "IE9813461A")
+          new JProperty("SUMUP", "IE9813461A"),
+          new JProperty("ICARD", "BG175325806")
         ).ToString();
         }
       </set-body>


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
This PR proposes to add the ICARD mapping to the abi-fiscalCode conversion map.

### List of changes

<!--- Describe your changes in detail -->
- Update policy

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->
The abi-fiscalcode conversion map needs to be updated with the new acquirer.

### Type of changes

- [ ] Add new resources
- [X] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [X] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [X] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
