### PR TITLE
[TAE-187] Add script to create tables in TAE db in Data Explorer

### DIFF
--- a/src/domains/tae-app/00_monitor.tf
+++ b/src/domains/tae-app/00_monitor.tf
@@ -31,3 +31,15 @@ data "azurerm_kusto_database" "tae_db" {
   resource_group_name = var.monitor_resource_group_name
   cluster_name        = data.azurerm_kusto_cluster.dexp_cluster[count.index].name
 }
+
+resource "azurerm_kusto_script" "create_tables" {
+
+  count = var.dexp_tae_db_linkes_service.enable ? 1 : 0
+
+  name        = "CreateTables"
+  database_id = data.azurerm_kusto_database.tae_db[count.index].id
+
+  script_content                     = file("scripts/create_tables.dexp")
+  continue_on_errors_enabled         = true
+  force_an_update_when_value_changed = "v3" # change this version to re-execute the script
+}

--- a/src/domains/tae-app/README.md
+++ b/src/domains/tae-app/README.md
@@ -34,6 +34,7 @@ No modules.
 | [azurerm_data_factory_trigger_blob_event.acquirer_aggregate](https://registry.terraform.io/providers/hashicorp/azurerm/3.14.0/docs/resources/data_factory_trigger_blob_event) | resource |
 | [azurerm_data_factory_trigger_schedule.ade_ack](https://registry.terraform.io/providers/hashicorp/azurerm/3.14.0/docs/resources/data_factory_trigger_schedule) | resource |
 | [azurerm_kusto_database_principal_assignment.tae_principal_assignment](https://registry.terraform.io/providers/hashicorp/azurerm/3.14.0/docs/resources/kusto_database_principal_assignment) | resource |
+| [azurerm_kusto_script.create_tables](https://registry.terraform.io/providers/hashicorp/azurerm/3.14.0/docs/resources/kusto_script) | resource |
 | [azuread_group.adgroup_admin](https://registry.terraform.io/providers/hashicorp/azuread/2.21.0/docs/data-sources/group) | data source |
 | [azuread_group.adgroup_developers](https://registry.terraform.io/providers/hashicorp/azuread/2.21.0/docs/data-sources/group) | data source |
 | [azuread_group.adgroup_externals](https://registry.terraform.io/providers/hashicorp/azuread/2.21.0/docs/data-sources/group) | data source |

--- a/src/domains/tae-app/scripts/create_tables.dexp
+++ b/src/domains/tae-app/scripts/create_tables.dexp
@@ -1,0 +1,8 @@
+.create table Aggregates(id: string, senderCode: string, operationType: string, 
+    transmissionDate: datetime, accountingDate: datetime, numTrx: int, 
+    totalAmount: int, currency: string, acquirerId: string, merchantId: string,
+    terminalId: string, fiscalCode: string, vat: string, posType: string, 
+    fileName: string, pipelineRun: string)
+
+.create table Acks(id: string, status: int, errorCode: string, fileName: string,
+    pipelineRun: string)


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
This PR proposes to create two tables in TAE DB of Data Explorer: the first, named `Aggregates`, is meant to log aggregates  by Senders, the second, named `Acks`, is meant to log acks from AdE


### List of changes

<!--- Describe your changes in detail -->
- New script to create Aggregates and Acks tables in Data Explorer

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->
Implement application metrics and dashboards

### Type of changes

- [ ] Add new resources
- [ ] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
