### PR TITLE
fix: VPN dev problem - changed range cird for dev dns forwarder

### DIFF
--- a/src/core/env/dev/terraform.tfvars
+++ b/src/core/env/dev/terraform.tfvars
@@ -28,12 +28,11 @@ cidr_subnet_azdoa        = ["10.1.130.0/24"]
 cidr_subnet_jumpbox      = ["10.1.131.0/24"]
 cidr_subnet_redis        = ["10.1.132.0/24"]
 cidr_subnet_vpn          = ["10.1.133.0/24"]
-cidr_subnet_dnsforwarder = ["10.1.134.0/29"]
 cidr_subnet_adf          = ["10.1.135.0/24"]
-
 cidr_subnet_flex_dbms        = ["10.1.136.0/24"]
 cidr_subnet_storage_account  = ["10.1.137.0/24"]
 cidr_subnet_cosmos_mongodb   = ["10.1.138.0/24"]
+cidr_subnet_dnsforwarder = ["10.1.199.0/29"]
 cidr_subnet_private_endpoint = ["10.1.200.0/23"]
 
 # IDPAY - cidr utilizzati sul progetto IdPay

--- a/src/core/env/dev/terraform.tfvars
+++ b/src/core/env/dev/terraform.tfvars
@@ -21,18 +21,18 @@ apim_sku                       = "Developer_1"
 
 cidr_vnet = ["10.1.0.0/16"]
 
-cidr_subnet_k8s          = ["10.1.0.0/17"]
-cidr_subnet_appgateway   = ["10.1.128.0/24"]
-cidr_subnet_db           = ["10.1.129.0/24"]
-cidr_subnet_azdoa        = ["10.1.130.0/24"]
-cidr_subnet_jumpbox      = ["10.1.131.0/24"]
-cidr_subnet_redis        = ["10.1.132.0/24"]
-cidr_subnet_vpn          = ["10.1.133.0/24"]
-cidr_subnet_adf          = ["10.1.135.0/24"]
+cidr_subnet_k8s              = ["10.1.0.0/17"]
+cidr_subnet_appgateway       = ["10.1.128.0/24"]
+cidr_subnet_db               = ["10.1.129.0/24"]
+cidr_subnet_azdoa            = ["10.1.130.0/24"]
+cidr_subnet_jumpbox          = ["10.1.131.0/24"]
+cidr_subnet_redis            = ["10.1.132.0/24"]
+cidr_subnet_vpn              = ["10.1.133.0/24"]
+cidr_subnet_adf              = ["10.1.135.0/24"]
 cidr_subnet_flex_dbms        = ["10.1.136.0/24"]
 cidr_subnet_storage_account  = ["10.1.137.0/24"]
 cidr_subnet_cosmos_mongodb   = ["10.1.138.0/24"]
-cidr_subnet_dnsforwarder = ["10.1.199.0/29"]
+cidr_subnet_dnsforwarder     = ["10.1.199.0/29"]
 cidr_subnet_private_endpoint = ["10.1.200.0/23"]
 
 # IDPAY - cidr utilizzati sul progetto IdPay


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

- changed cird for dev dns forwarder

### Motivation and context

The old cird for dns forwarder has the ip already used, this thing cause the vpn dev to stop working.

To fix the problem we move the dev cird to other range

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
