### PR TITLE
[RTD-520] Added indexes to senderauth collection

### DIFF
--- a/src/core/rtd_database.tf
+++ b/src/core/rtd_database.tf
@@ -101,6 +101,15 @@ resource "azurerm_cosmosdb_mongo_collection" "sender_auth" {
     keys   = ["_id"]
     unique = true
   }
+
+  index {
+    keys   = ["apiKey"]
+    unique = true
+  }
+
+  index {
+    keys = ["senderCodes"]
+  }
 }
 
 resource "azurerm_cosmosdb_mongo_collection" "file_register" {


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
This PR adds indexes over `apiKey` and `senderCodes` key to improve query performance by rtd-ms-sender-auth.

### List of changes
- apiKey as index and unique
- senderCodes as index

<!--- Describe your changes in detail -->
Cause mongo db documents are retrieved by `apiKey` using it as index should improve query performance. Furthermore `senderCodes` is used to check if a sender code is already associated to another apiKey, indexing it should improve query.

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
Creating indexes on existing collection with documents is prohibited. So these actions need to be performed on each environment to successfully migrate the collection:
- dump collection
- create indexes using terraform
- restore collection

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
