### PR TITLE
[RTD-539] Enrolled pim producer config

### DIFF
--- a/src/domains/idpay-app/01_keyvault.tf
+++ b/src/domains/idpay-app/01_keyvault.tf
@@ -3,14 +3,21 @@ data "azurerm_kubernetes_cluster" "aks" {
   resource_group_name = local.aks_resource_group_name
 }
 
-# retrieve enrolled payment instrument event hub role to get connection string
+# retrieve enrolled pim hub to take partition count
+data "azurerm_eventhub" "enrolled_pi_hub" {
+  name                = var.eventhub_enrolled_pi.eventhub_name
+  namespace_name      = var.eventhub_enrolled_pi.namespace_name
+  resource_group_name = var.eventhub_enrolled_pi.resource_group_name
+}
 
+# retrieve enrolled payment instrument event hub role to get connection string
 data "azurerm_eventhub_authorization_rule" "enrolled_pi_producer_role" {
   name                = "rtd-enrolled-pi-producer-policy"
   namespace_name      = var.eventhub_enrolled_pi.namespace_name
   resource_group_name = var.eventhub_enrolled_pi.resource_group_name
-  eventhub_name       = "rtd-enrolled-pi"
+  eventhub_name       = var.eventhub_enrolled_pi.eventhub_name
 }
+
 
 locals {
   aks_api_url = var.env_short == "d" ? data.azurerm_kubernetes_cluster.aks.fqdn : data.azurerm_kubernetes_cluster.aks.private_fqdn

--- a/src/domains/idpay-app/08_k8s_configmaps.tf
+++ b/src/domains/idpay-app/08_k8s_configmaps.tf
@@ -81,8 +81,10 @@ resource "kubernetes_config_map" "rtd-eventhub" {
   }
 
   data = {
-    kafka_broker_rtd      = "${local.product}-evh-ns.servicebus.windows.net:${var.event_hub_port}"
-    rtd_enrolled_pi_topic = "rtd-enrolled-pi"
+    kafka_broker_rtd               = "${local.product}-evh-ns.servicebus.windows.net:${var.event_hub_port}"
+    rtd_enrolled_pi_topic          = "rtd-enrolled-pi"
+    kafka_partition_count          = data.azurerm_eventhub.enrolled_pi_hub.partition_count
+    kafka_partition_key_expression = "headers.partitionKey"
   }
 
 }

--- a/src/domains/idpay-app/99_variables.tf
+++ b/src/domains/idpay-app/99_variables.tf
@@ -159,6 +159,7 @@ variable "reverse_proxy_be_io" {
 
 variable "eventhub_enrolled_pi" {
   type = object({
+    eventhub_name       = string
     resource_group_name = string,
     namespace_name      = string
   })

--- a/src/domains/idpay-app/README.md
+++ b/src/domains/idpay-app/README.md
@@ -65,6 +65,7 @@
 | [azurerm_api_management.apim_core](https://registry.terraform.io/providers/hashicorp/azurerm/2.99.0/docs/data-sources/api_management) | data source |
 | [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/2.99.0/docs/data-sources/client_config) | data source |
 | [azurerm_dns_zone.public](https://registry.terraform.io/providers/hashicorp/azurerm/2.99.0/docs/data-sources/dns_zone) | data source |
+| [azurerm_eventhub.enrolled_pi_hub](https://registry.terraform.io/providers/hashicorp/azurerm/2.99.0/docs/data-sources/eventhub) | data source |
 | [azurerm_eventhub_authorization_rule.enrolled_pi_producer_role](https://registry.terraform.io/providers/hashicorp/azurerm/2.99.0/docs/data-sources/eventhub_authorization_rule) | data source |
 | [azurerm_key_vault.kv](https://registry.terraform.io/providers/hashicorp/azurerm/2.99.0/docs/data-sources/key_vault) | data source |
 | [azurerm_key_vault_secret.cdn_storage_access_secret](https://registry.terraform.io/providers/hashicorp/azurerm/2.99.0/docs/data-sources/key_vault_secret) | data source |
@@ -94,7 +95,7 @@
 | <a name="input_env"></a> [env](#input\_env) | n/a | `string` | n/a | yes |
 | <a name="input_env_short"></a> [env\_short](#input\_env\_short) | n/a | `string` | n/a | yes |
 | <a name="input_event_hub_port"></a> [event\_hub\_port](#input\_event\_hub\_port) | n/a | `number` | `9093` | no |
-| <a name="input_eventhub_enrolled_pi"></a> [eventhub\_enrolled\_pi](#input\_eventhub\_enrolled\_pi) | Namespace and groupname configuration for enrolled payment instrument eventhub | <pre>object({<br>    resource_group_name = string,<br>    namespace_name      = string<br>  })</pre> | n/a | yes |
+| <a name="input_eventhub_enrolled_pi"></a> [eventhub\_enrolled\_pi](#input\_eventhub\_enrolled\_pi) | Namespace and groupname configuration for enrolled payment instrument eventhub | <pre>object({<br>    eventhub_name       = string<br>    resource_group_name = string,<br>    namespace_name      = string<br>  })</pre> | n/a | yes |
 | <a name="input_external_domain"></a> [external\_domain](#input\_external\_domain) | Domain for delegation | `string` | `"pagopa.it"` | no |
 | <a name="input_ingress_load_balancer_hostname"></a> [ingress\_load\_balancer\_hostname](#input\_ingress\_load\_balancer\_hostname) | n/a | `string` | n/a | yes |
 | <a name="input_ingress_load_balancer_ip"></a> [ingress\_load\_balancer\_ip](#input\_ingress\_load\_balancer\_ip) | n/a | `string` | n/a | yes |

--- a/src/domains/idpay-app/env/dev/terraform.tfvars
+++ b/src/domains/idpay-app/env/dev/terraform.tfvars
@@ -55,6 +55,7 @@ enable = {
 
 # Enrolled payment instrument event hub
 eventhub_enrolled_pi = {
+  eventhub_name       = "rtd-enrolled-pi"
   namespace_name      = "cstar-d-evh-ns"
   resource_group_name = "cstar-d-msg-rg"
 }

--- a/src/domains/idpay-app/env/uat/terraform.tfvars
+++ b/src/domains/idpay-app/env/uat/terraform.tfvars
@@ -55,6 +55,7 @@ enable = {
 
 # Enrolled payment instrument event hub
 eventhub_enrolled_pi = {
+  eventhub_name       = "rtd-enrolled-pi"
   namespace_name      = "cstar-u-evh-ns"
   resource_group_name = "cstar-u-msg-rg"
 }

--- a/src/k8s/README.md
+++ b/src/k8s/README.md
@@ -194,6 +194,7 @@ pre-commit run -a
 | [kubernetes_config_map.rtd-eventhub-common](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/config_map) | resource |
 | [kubernetes_config_map.rtd-eventhub-logging](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/config_map) | resource |
 | [kubernetes_config_map.rtd-jvm](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/config_map) | resource |
+| [kubernetes_config_map.rtd-producer-enrolledpaymentinstrument](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/config_map) | resource |
 | [kubernetes_config_map.rtd-rest-client](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/config_map) | resource |
 | [kubernetes_config_map.rtddecrypter](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/config_map) | resource |
 | [kubernetes_config_map.rtdingestor](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/config_map) | resource |
@@ -246,6 +247,7 @@ pre-commit run -a
 | [azuread_group.adgroup_security](https://registry.terraform.io/providers/hashicorp/azuread/1.6.0/docs/data-sources/group) | data source |
 | [azuread_group.adgroup_technical_project_managers](https://registry.terraform.io/providers/hashicorp/azuread/1.6.0/docs/data-sources/group) | data source |
 | [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/2.70.0/docs/data-sources/client_config) | data source |
+| [azurerm_eventhub.rtd-enrolled-pi](https://registry.terraform.io/providers/hashicorp/azurerm/2.70.0/docs/data-sources/eventhub) | data source |
 | [azurerm_subscription.current](https://registry.terraform.io/providers/hashicorp/azurerm/2.70.0/docs/data-sources/subscription) | data source |
 | [kubernetes_secret.azure_devops_secret](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/data-sources/secret) | data source |
 
@@ -281,6 +283,7 @@ pre-commit run -a
 | <a name="input_configmaps_rtddecrypter"></a> [configmaps\_rtddecrypter](#input\_configmaps\_rtddecrypter) | n/a | `map(string)` | `{}` | no |
 | <a name="input_configmaps_rtdenrolledpaymentinstrument"></a> [configmaps\_rtdenrolledpaymentinstrument](#input\_configmaps\_rtdenrolledpaymentinstrument) | n/a | `map(string)` | n/a | yes |
 | <a name="input_configmaps_rtdpaymentinstrumentmanager"></a> [configmaps\_rtdpaymentinstrumentmanager](#input\_configmaps\_rtdpaymentinstrumentmanager) | n/a | `map(string)` | n/a | yes |
+| <a name="input_configmaps_rtdproducerenrolledpaymentinstrument"></a> [configmaps\_rtdproducerenrolledpaymentinstrument](#input\_configmaps\_rtdproducerenrolledpaymentinstrument) | n/a | `map(string)` | n/a | yes |
 | <a name="input_configmaps_rtdtransactionfilter"></a> [configmaps\_rtdtransactionfilter](#input\_configmaps\_rtdtransactionfilter) | n/a | `map(string)` | `{}` | no |
 | <a name="input_default_service_port"></a> [default\_service\_port](#input\_default\_service\_port) | n/a | `number` | `8080` | no |
 | <a name="input_enable"></a> [enable](#input\_enable) | Feature flags | <pre>object({<br>    rtd = object({<br>      blob_storage_event_grid_integration = bool<br>      internal_api                        = bool<br>      csv_transaction_apis                = bool<br>      ingestor                            = bool<br>      file_register                       = bool<br>      enrolled_payment_instrument         = bool<br>      mongodb_storage                     = bool<br>    })<br>    fa = object({<br>      api = bool<br>    })<br>  })</pre> | <pre>{<br>  "fa": {<br>    "api": false<br>  },<br>  "rtd": {<br>    "blob_storage_event_grid_integration": false,<br>    "csv_transaction_apis": false,<br>    "enrolled_payment_instrument": false,<br>    "file_register": false,<br>    "ingestor": false,<br>    "internal_api": false,<br>    "mongodb_storage": false<br>  }<br>}</pre> | no |
@@ -288,6 +291,7 @@ pre-commit run -a
 | <a name="input_env"></a> [env](#input\_env) | n/a | `string` | n/a | yes |
 | <a name="input_env_short"></a> [env\_short](#input\_env\_short) | n/a | `string` | n/a | yes |
 | <a name="input_event_hub_port"></a> [event\_hub\_port](#input\_event\_hub\_port) | n/a | `number` | `9093` | no |
+| <a name="input_eventhub_enrolled_pi"></a> [eventhub\_enrolled\_pi](#input\_eventhub\_enrolled\_pi) | n/a | <pre>object({<br>    name                = string,<br>    namespace_name      = string,<br>    resource_group_name = string<br>  })</pre> | n/a | yes |
 | <a name="input_ingress_load_balancer_ip"></a> [ingress\_load\_balancer\_ip](#input\_ingress\_load\_balancer\_ip) | n/a | `string` | n/a | yes |
 | <a name="input_ingress_replica_count"></a> [ingress\_replica\_count](#input\_ingress\_replica\_count) | n/a | `string` | n/a | yes |
 | <a name="input_k8s_apiserver_host"></a> [k8s\_apiserver\_host](#input\_k8s\_apiserver\_host) | n/a | `string` | n/a | yes |

--- a/src/k8s/rtd_configmaps.tf
+++ b/src/k8s/rtd_configmaps.tf
@@ -61,11 +61,10 @@ resource "kubernetes_config_map" "rtddecrypter" {
   data = merge({
     JAVA_TOOL_OPTIONS                = "-javaagent:/app/applicationinsights-agent.jar"
     CSV_TRANSACTION_PRIVATE_KEY_PATH = "/home/certs/private.key"
-    CSV_TRANSACTION_DECRYPT_HOST = replace(format("apim.internal.%s.cstar.pagopa.it", local.environment_name), ".."
-    , ".")
-    SPLITTER_LINE_THRESHOLD = 250000,
-    ENABLE_CHUNK_UPLOAD     = true,
-    CONSUMER_TIMEOUT_MS     = 7200000 # 2h
+    CSV_TRANSACTION_DECRYPT_HOST     = replace(format("apim.internal.%s.cstar.pagopa.it", local.environment_name), "..", ".")
+    SPLITTER_LINE_THRESHOLD          = 250000,
+    ENABLE_CHUNK_UPLOAD              = true,
+    CONSUMER_TIMEOUT_MS              = 7200000 # 2h
     },
   var.configmaps_rtddecrypter)
 }
@@ -80,8 +79,8 @@ resource "kubernetes_config_map" "rtdingestor" {
 
   data = {
     JAVA_TOOL_OPTIONS = "-javaagent:/app/applicationinsights-agent.jar"
-    CSV_INGESTOR_HOST = replace(format("apim.internal.%s.cstar.pagopa.it", local.environment_name), ".."
-  , ".") }
+    CSV_INGESTOR_HOST = replace(format("apim.internal.%s.cstar.pagopa.it", local.environment_name), "..", ".")
+  }
 }
 
 resource "kubernetes_config_map" "rtd-eventhub-common" {
@@ -148,4 +147,22 @@ resource "kubernetes_config_map" "rtd-enrolledpaymentinstrument" {
     },
     var.configmaps_rtdenrolledpaymentinstrument
   )
+}
+
+# Get event hub to take partition count
+data "azurerm_eventhub" "rtd-enrolled-pi" {
+  name                = var.eventhub_enrolled_pi.name
+  resource_group_name = var.eventhub_enrolled_pi.resource_group_name
+  namespace_name      = var.eventhub_enrolled_pi.namespace_name
+}
+
+resource "kubernetes_config_map" "rtd-producer-enrolledpaymentinstrument" {
+  metadata {
+    name      = "rtd-producer-enrolledpaymentinstrument"
+    namespace = kubernetes_namespace.rtd.metadata[0].name
+  }
+
+  data = merge({
+    KAFKA_PARTITION_COUNT = data.azurerm_eventhub.rtd-enrolled-pi.partition_count
+  }, var.configmaps_rtdproducerenrolledpaymentinstrument)
 }

--- a/src/k8s/subscriptions/DEV-CSTAR/terraform.tfvars
+++ b/src/k8s/subscriptions/DEV-CSTAR/terraform.tfvars
@@ -357,6 +357,11 @@ configmaps_rtdenrolledpaymentinstrument = {
   APPLICATIONINSIGHTS_INSTRUMENTATION_MICROMETER_ENABLED = "false"
 }
 
+configmaps_rtdproducerenrolledpaymentinstrument = {
+  KAFKA_PARTITION_KEY_EXPRESSION = "headers.partitionKey"
+  KAFKA_PARTITION_COUNT          = 1
+}
+
 autoscaling_specs = {
 
   # map key must be the name of a deployment
@@ -480,4 +485,10 @@ enable = {
   fa = {
     api = true
   }
+}
+
+eventhub_enrolled_pi = {
+  name                = "rtd-enrolled-pi"
+  namespace_name      = "cstar-d-evh-ns"
+  resource_group_name = "cstar-d-msg-rg"
 }

--- a/src/k8s/subscriptions/PROD-CSTAR/terraform.tfvars
+++ b/src/k8s/subscriptions/PROD-CSTAR/terraform.tfvars
@@ -390,6 +390,11 @@ configmaps_rtdenrolledpaymentinstrument = {
   APPLICATIONINSIGHTS_INSTRUMENTATION_MICROMETER_ENABLED = "false"
 }
 
+configmaps_rtdproducerenrolledpaymentinstrument = {
+  KAFKA_PARTITION_KEY_EXPRESSION = "headers.partitionKey"
+  KAFKA_PARTITION_COUNT          = 1
+}
+
 autoscaling_specs = {
 
   # map key must be the name of a deployment
@@ -670,4 +675,10 @@ enable = {
   fa = {
     api = false
   }
+}
+
+eventhub_enrolled_pi = {
+  name                = "rtd-enrolled-pi"
+  namespace_name      = "cstar-p-evh-ns"
+  resource_group_name = "cstar-p-msg-rg"
 }

--- a/src/k8s/subscriptions/UAT-CSTAR/terraform.tfvars
+++ b/src/k8s/subscriptions/UAT-CSTAR/terraform.tfvars
@@ -387,6 +387,11 @@ configmaps_rtdenrolledpaymentinstrument = {
   APPLICATIONINSIGHTS_INSTRUMENTATION_MICROMETER_ENABLED = "false"
 }
 
+configmaps_rtdproducerenrolledpaymentinstrument = {
+  KAFKA_PARTITION_KEY_EXPRESSION = "headers.partitionKey"
+  KAFKA_PARTITION_COUNT          = 1
+}
+
 autoscaling_specs = {
 
   # map key must be the name of a deployment
@@ -504,4 +509,10 @@ enable = {
   fa = {
     api = true
   }
+}
+
+eventhub_enrolled_pi = {
+  name                = "rtd-enrolled-pi"
+  namespace_name      = "cstar-u-evh-ns"
+  resource_group_name = "cstar-u-msg-rg"
 }

--- a/src/k8s/variables.tf
+++ b/src/k8s/variables.tf
@@ -210,6 +210,10 @@ variable "configmaps_rtdenrolledpaymentinstrument" {
   type = map(string)
 }
 
+variable "configmaps_rtdproducerenrolledpaymentinstrument" {
+  type = map(string)
+}
+
 variable "autoscaling_specs" {
   type = map(object({
     namespace    = string
@@ -264,4 +268,12 @@ variable "enable" {
       api = false
     }
   }
+}
+
+variable "eventhub_enrolled_pi" {
+  type = object({
+    name                = string,
+    namespace_name      = string,
+    resource_group_name = string
+  })
 }


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
This PR adds config map as a producer for rtd-enrolled-pi eventhub. The config map includes partitionCount and partitionKey expression.

### List of changes
- added partitionCount and partitionKey configmap to idpay domain
- added configmap to old rtd k8s cluster

<!--- Describe your changes in detail -->

### Motivation and context
This solve concurrency issue over rtd enrolled payment instrument microservice by design. Every producer produce to a specific partition this allows the same consumer to process the same set of events.
<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Applied to "old" rtd k8s and to idpay domain
---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
