### PR TITLE
[RTD-582] Added ingress template to sender-ack-filename-list endpoint

### DIFF
--- a/src/core/api/rtd_senderack_filename_list/policy.xml.tpl
+++ b/src/core/api/rtd_senderack_filename_list/policy.xml.tpl
@@ -15,7 +15,7 @@
     <choose>
       <when condition="@(((IResponse)context.Variables["senderCode"]).StatusCode == 200)">
       <!-- join sender codes using "," to obtain sendercode1,sendercode,etc... -->
-        <set-backend-service base-url="http://10.1.0.250/rtdmsfileregister" />
+        <set-backend-service base-url="http://${rtd-ingress-ip}/rtdmsfileregister" />
         <set-query-parameter name="senders" exists-action="override">
           <value>@(string.Join(",", ((IResponse)context.Variables["senderCode"]).Body.As<JArray>()))</value>
         </set-query-parameter>

--- a/src/core/api_rtd.tf
+++ b/src/core/api_rtd.tf
@@ -340,7 +340,7 @@ module "rtd_senderadeack_filename_list" {
     host = "https://httpbin.org"
   })
 
-  xml_content = templatefile("./api/rtd_senderack_filename_list/policy.xml", {
+  xml_content = templatefile("./api/rtd_senderack_filename_list/policy.xml.tpl", {
     rtd-ingress-ip = var.reverse_proxy_ip
   })
 


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
This PR remove technical debt due to missing ingress template variable inside `senderack-filename-list` policy

### List of changes

<!--- Describe your changes in detail -->

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new resources
- [ ] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
