### PR TITLE
[RTD-646] Fix TPAY1 FC

### DIFF
--- a/src/core/api/rtd_abi_to_fiscalcode/policy.xml.tpl
+++ b/src/core/api/rtd_abi_to_fiscalcode/policy.xml.tpl
@@ -12,7 +12,7 @@
           new JProperty("BPAY1", "04949971008"),
           new JProperty("SUMUP", "IE9813461A"),
           new JProperty("ICARD", "BG175325806"),
-          new JProperty("TPAY1", "9771701001")
+          new JProperty("TPAY1", "09771701001")
         ).ToString();
         }
       </set-body>


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
This PR proposes to fix Telepass Pay fiscal code with a missing leading 0.
### List of changes

<!--- Describe your changes in detail -->

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [x] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
```
--target="module.rtd_fake_abi_to_fiscal_code[0].azurerm_api_management_api_policy.this[0]"
```
---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
