### PR TITLE
[RTD-638] Propagate eventhub jaas config to new rtd kv

### DIFF
--- a/src/domains/rtd-common/04_eventhub_external.tf
+++ b/src/domains/rtd-common/04_eventhub_external.tf
@@ -1,0 +1,14 @@
+locals {
+  jaas_config_template_rtd = "org.apache.kafka.common.security.plain.PlainLoginModule required username=\"$ConnectionString\" password=\"%s\";"
+}
+
+# propagate external event hub jaas config to new keyvault. Also exclude bpd config
+resource "azurerm_key_vault_secret" "rtd_event_hub_jaas_config" {
+  for_each = { for key, val in data.terraform_remote_state.core.outputs.event_hub_keys_ids : key => val if length(split("bpd", key)) <= 1 }
+
+  name         = format("evh-%s-%s", replace(each.key, ".", "-"), "key")
+  value        = format(local.jaas_config_template_rtd, data.terraform_remote_state.core.outputs.event_hub_keys[each.key].primary_connection_string)
+  content_type = "text/plain"
+
+  key_vault_id = module.key_vault_domain.id
+}

--- a/src/domains/rtd-common/README.md
+++ b/src/domains/rtd-common/README.md
@@ -25,6 +25,7 @@
 | [azurerm_key_vault_access_policy.adgroup_developers_policy](https://registry.terraform.io/providers/hashicorp/azurerm/2.99.0/docs/resources/key_vault_access_policy) | resource |
 | [azurerm_key_vault_access_policy.adgroup_externals_policy](https://registry.terraform.io/providers/hashicorp/azurerm/2.99.0/docs/resources/key_vault_access_policy) | resource |
 | [azurerm_key_vault_access_policy.azdevops_platform_iac_policy](https://registry.terraform.io/providers/hashicorp/azurerm/2.99.0/docs/resources/key_vault_access_policy) | resource |
+| [azurerm_key_vault_secret.rtd_event_hub_jaas_config](https://registry.terraform.io/providers/hashicorp/azurerm/2.99.0/docs/resources/key_vault_secret) | resource |
 | [azurerm_private_dns_a_record.data_factory_a_record](https://registry.terraform.io/providers/hashicorp/azurerm/2.99.0/docs/resources/private_dns_a_record) | resource |
 | [azurerm_private_endpoint.data_factory_pe](https://registry.terraform.io/providers/hashicorp/azurerm/2.99.0/docs/resources/private_endpoint) | resource |
 | [azurerm_resource_group.data_factory_rg](https://registry.terraform.io/providers/hashicorp/azurerm/2.99.0/docs/resources/resource_group) | resource |


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes
This PR stars migration to new rtd k8s cluster. It propagate jaas configuration from the external eventhub (rtd) to new rtd keyvault.

<!--- Describe your changes in detail -->

### Motivation and context
Migration to new rtd k8s cluster

<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [x] Add new resources
- [ ] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
