### PR TITLE
feat: [RTD-592] Add sender-auth authorization call to download ack

### DIFF
--- a/src/core/api/rtd_senderack_download_file/azureblob_policy.xml
+++ b/src/core/api/rtd_senderack_download_file/azureblob_policy.xml
@@ -1,25 +1,41 @@
-
-
 <policies>
     <inbound>
       <base />
+      <set-variable name="keyHash" value="@{
+                    System.Security.Cryptography.SHA256 hasher = System.Security.Cryptography.SHA256.Create();
+                    return BitConverter.ToString(hasher.ComputeHash(System.Text.Encoding.UTF8.GetBytes(context.Request.Headers.GetValueOrDefault("Ocp-Apim-Subscription-Key","")))).Replace("-", "").ToLowerInvariant();
+      }"/>
       <set-variable name="senderAdeAckName" value="@(context.Request.MatchedParameters["fileName"])" />
-
       <set-variable name="containerName" value="@{return string.Format("{0}",
-      ((string)context.Request.MatchedParameters["fileName"]).Substring(7, 5));
-      }"
-      />
+            ((string)context.Request.MatchedParameters["fileName"]).Substring(7, 5));
+      }"/>
+      <set-variable name="senderCode" value='@(context.Variables["containerName"])'/>
 
-      <rewrite-uri template="@((context.Variables["containerName"])+"/{fileName}")"/>
+      <send-request mode="new" response-variable-name="authorization" timeout="60" ignore-error="true">
+          <set-url>@("http://${rtd-ingress-ip}/rtdmssenderauth/authorize/" + (string)context.Variables["senderCode"])</set-url>
+          <set-method>GET</set-method>
+          <set-header name="internal-id" exists-action="override">@(context.Variables["keyHash"])</set-header>
+      </send-request>
 
-      <authentication-managed-identity resource="https://storage.azure.com/" output-token-variable-name="msi-access-token" ignore-error="false" />
-      <set-header name="X-Ms-Version" exists-action="override">
-        <value>2019-12-12</value>
-      </set-header>
-      <set-header name="Authorization" exists-action="override">
-        <value>@("Bearer " + (string)context.Variables["msi-access-token"])</value>
-      </set-header>
+      <choose>
+        <when condition="@(((IResponse)context.Variables["authorization"]).StatusCode == 200)">
+            <rewrite-uri template="@((context.Variables["containerName"])+"/{fileName}")"/>
 
+            <authentication-managed-identity resource="https://storage.azure.com/" output-token-variable-name="msi-access-token" ignore-error="false" />
+            <set-header name="X-Ms-Version" exists-action="override">
+                <value>2019-12-12</value>
+            </set-header>
+            <set-header name="Authorization" exists-action="override">
+                <value>@("Bearer " + (string)context.Variables["msi-access-token"])</value>
+            </set-header>
+        </when>
+        <otherwise>
+            <return-response>
+                <set-status code="400" reason="Bad Request" />
+                <set-body />
+            </return-response>
+        </otherwise>
+      </choose>
     </inbound>
     <backend>
         <base />

--- a/src/core/api/rtd_senderack_download_file/azureblob_policy.xml
+++ b/src/core/api/rtd_senderack_download_file/azureblob_policy.xml
@@ -9,12 +9,14 @@
       <set-variable name="containerName" value="@{return string.Format("{0}",
             ((string)context.Request.MatchedParameters["fileName"]).Substring(7, 5));
       }"/>
-      <set-variable name="senderCode" value='@(context.Variables["containerName"])'/>
+      <set-variable name="senderCode" value="@((string)context.Variables["containerName"])"/>
 
       <send-request mode="new" response-variable-name="authorization" timeout="60" ignore-error="true">
           <set-url>@("http://${rtd-ingress-ip}/rtdmssenderauth/authorize/" + (string)context.Variables["senderCode"])</set-url>
           <set-method>GET</set-method>
-          <set-header name="internal-id" exists-action="override">@(context.Variables["keyHash"])</set-header>
+          <set-header name="internal-id" exists-action="override">
+              <value>@((string)context.Variables["keyHash"])</value>
+          </set-header>
       </send-request>
 
       <choose>


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
This PR adds authorization call to sender-auth before download an ade ack file.

### List of changes

<!--- Describe your changes in detail -->

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new resources
- [ ] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)
`-target="module.rtd_senderack_download_file"`
<!--- Describe the blocking cause -->
