### PR TITLE
feat: [RTD-721] Added rtd revoke queue

### DIFF
--- a/src/core/env/dev/terraform.tfvars
+++ b/src/core/env/dev/terraform.tfvars
@@ -618,26 +618,6 @@ eventhubs = [
     ]
   },
   {
-    name              = "rtd-log"
-    partitions        = 1
-    message_retention = 1
-    consumers         = ["elk"]
-    keys = [
-      {
-        name   = "app"
-        listen = false
-        send   = true
-        manage = false
-      },
-      {
-        name   = "elk"
-        listen = true
-        send   = false
-        manage = false
-      }
-    ]
-  },
-  {
     name              = "rtd-platform-events"
     partitions        = 1
     message_retention = 1

--- a/src/core/env/dev/terraform.tfvars
+++ b/src/core/env/dev/terraform.tfvars
@@ -707,6 +707,26 @@ eventhubs = [
         manage = false
       }
     ]
+  },
+  {
+    name              = "rtd-revoked-pi"
+    partitions        = 1
+    message_retention = 1
+    consumers         = ["rtd-revoked-payment-instrument-consumer-group"]
+    keys = [
+      {
+        name   = "rtd-revoked-pi-consumer-policy"
+        listen = true
+        send   = false
+        manage = false
+      },
+      {
+        name   = "rtd-revoked-pi-producer-policy"
+        listen = false
+        send   = true
+        manage = false
+      }
+    ]
   }
 ]
 

--- a/src/core/env/prod/terraform.tfvars
+++ b/src/core/env/prod/terraform.tfvars
@@ -679,26 +679,6 @@ eventhubs = [
     ]
   },
   {
-    name              = "rtd-revoked-pi"
-    partitions        = 1
-    message_retention = 1
-    consumers         = ["rtd-revoked-payment-instrument-consumer-group"]
-    keys = [
-      {
-        name   = "rtd-revoked-pi-consumer-policy"
-        listen = true
-        send   = false
-        manage = false
-      },
-      {
-        name   = "rtd-revoked-pi-producer-policy"
-        listen = false
-        send   = true
-        manage = false
-      }
-    ]
-  },
-  {
     name              = "tkm-write-update-token"
     partitions        = 1
     message_retention = 1

--- a/src/core/env/prod/terraform.tfvars
+++ b/src/core/env/prod/terraform.tfvars
@@ -679,6 +679,26 @@ eventhubs = [
     ]
   },
   {
+    name              = "rtd-revoked-pi"
+    partitions        = 1
+    message_retention = 1
+    consumers         = ["rtd-revoked-payment-instrument-consumer-group"]
+    keys = [
+      {
+        name   = "rtd-revoked-pi-consumer-policy"
+        listen = true
+        send   = false
+        manage = false
+      },
+      {
+        name   = "rtd-revoked-pi-producer-policy"
+        listen = false
+        send   = true
+        manage = false
+      }
+    ]
+  },
+  {
     name              = "tkm-write-update-token"
     partitions        = 1
     message_retention = 1

--- a/src/core/env/prod/terraform.tfvars
+++ b/src/core/env/prod/terraform.tfvars
@@ -833,6 +833,26 @@ eventhubs_fa = [
       }
     ]
   },
+  { // to be removed from here, temporary allocated here due to limit of 10 queue in rtd namespace
+    name              = "rtd-revoked-pi"
+    partitions        = 1
+    message_retention = 1
+    consumers         = ["rtd-revoked-payment-instrument-consumer-group"]
+    keys = [
+      {
+        name   = "rtd-revoked-pi-consumer-policy"
+        listen = true
+        send   = false
+        manage = false
+      },
+      {
+        name   = "rtd-revoked-pi-producer-policy"
+        listen = false
+        send   = true
+        manage = false
+      }
+    ]
+  },
 ]
 
 external_domain = "pagopa.it"

--- a/src/core/env/uat/terraform.tfvars
+++ b/src/core/env/uat/terraform.tfvars
@@ -620,26 +620,6 @@ eventhubs = [
     ]
   },
   {
-    name              = "rtd-log"
-    partitions        = 1
-    message_retention = 1
-    consumers         = ["elk"]
-    keys = [
-      {
-        name   = "app"
-        listen = false
-        send   = true
-        manage = false
-      },
-      {
-        name   = "elk"
-        listen = true
-        send   = false
-        manage = false
-      }
-    ]
-  },
-  {
     name              = "rtd-platform-events"
     partitions        = 4
     message_retention = 7

--- a/src/core/env/uat/terraform.tfvars
+++ b/src/core/env/uat/terraform.tfvars
@@ -682,6 +682,26 @@ eventhubs = [
     ]
   },
   {
+    name              = "rtd-revoked-pi"
+    partitions        = 1
+    message_retention = 1
+    consumers         = ["rtd-revoked-payment-instrument-consumer-group"]
+    keys = [
+      {
+        name   = "rtd-revoked-pi-consumer-policy"
+        listen = true
+        send   = false
+        manage = false
+      },
+      {
+        name   = "rtd-revoked-pi-producer-policy"
+        listen = false
+        send   = true
+        manage = false
+      }
+    ]
+  },
+  {
     name              = "tkm-write-update-token"
     partitions        = 1
     message_retention = 1
@@ -709,7 +729,7 @@ eventhubs = [
         manage = false
       },
     ]
-  },
+  }
 ]
 
 eventhubs_fa = [

--- a/src/domains/idpay-app/01_keyvault.tf
+++ b/src/domains/idpay-app/01_keyvault.tf
@@ -5,19 +5,32 @@ data "azurerm_kubernetes_cluster" "aks" {
 
 # retrieve enrolled pim hub to take partition count
 data "azurerm_eventhub" "enrolled_pi_hub" {
-  name                = var.eventhub_enrolled_pi.eventhub_name
-  namespace_name      = var.eventhub_enrolled_pi.namespace_name
-  resource_group_name = var.eventhub_enrolled_pi.resource_group_name
+  name                = var.eventhub_pim.enrolled_pi_eventhub
+  namespace_name      = var.eventhub_pim.namespace_name
+  resource_group_name = var.eventhub_pim.resource_group_name
+}
+
+data "azurerm_eventhub" "revoked_pi_hub" {
+  name                = var.eventhub_pim.revoked_pi_eventhub
+  namespace_name      = var.eventhub_pim.namespace_name
+  resource_group_name = var.eventhub_pim.resource_group_name
 }
 
 # retrieve enrolled payment instrument event hub role to get connection string
 data "azurerm_eventhub_authorization_rule" "enrolled_pi_producer_role" {
   name                = "rtd-enrolled-pi-producer-policy"
-  namespace_name      = var.eventhub_enrolled_pi.namespace_name
-  resource_group_name = var.eventhub_enrolled_pi.resource_group_name
-  eventhub_name       = var.eventhub_enrolled_pi.eventhub_name
+  namespace_name      = var.eventhub_pim.namespace_name
+  resource_group_name = var.eventhub_pim.resource_group_name
+  eventhub_name       = var.eventhub_pim.enrolled_pi_eventhub
 }
 
+# retrieve enrolled payment instrument event hub role to get connection string
+data "azurerm_eventhub_authorization_rule" "revoked_pi_consumer_role" {
+  name                = "rtd-revoked-pi-consumer-policy"
+  namespace_name      = var.eventhub_pim.namespace_name
+  resource_group_name = var.eventhub_pim.resource_group_name
+  eventhub_name       = var.eventhub_pim.revoked_pi_eventhub
+}
 
 locals {
   aks_api_url = var.env_short == "d" ? data.azurerm_kubernetes_cluster.aks.fqdn : data.azurerm_kubernetes_cluster.aks.private_fqdn
@@ -36,4 +49,10 @@ resource "azurerm_key_vault_secret" "enrolled_pi_producer_connection_uri" {
   key_vault_id = data.azurerm_key_vault.kv.id
   name         = "${var.domain}-enrolled-pi-producer-connection-uri"
   value        = "org.apache.kafka.common.security.plain.PlainLoginModule required username=\"$ConnectionString\" password=\"${data.azurerm_eventhub_authorization_rule.enrolled_pi_producer_role.primary_connection_string}\";"
+}
+
+resource "azurerm_key_vault_secret" "revoked_pi_consumer_connection_uri" {
+  key_vault_id = data.azurerm_key_vault.kv.id
+  name         = "${var.domain}-revoked-pi-consumer-connection-uri"
+  value        = "org.apache.kafka.common.security.plain.PlainLoginModule required username=\"$ConnectionString\" password=\"${data.azurerm_eventhub_authorization_rule.revoked_pi_consumer_role.primary_connection_string}\";"
 }

--- a/src/domains/idpay-app/99_variables.tf
+++ b/src/domains/idpay-app/99_variables.tf
@@ -157,11 +157,12 @@ variable "reverse_proxy_be_io" {
   description = "AKS external ip. Also the ingress-nginx-controller external ip. Value known after installing the ingress controller."
 }
 
-variable "eventhub_enrolled_pi" {
+variable "eventhub_pim" {
   type = object({
-    eventhub_name       = string
-    resource_group_name = string,
-    namespace_name      = string
+    enrolled_pi_eventhub = string,
+    revoked_pi_eventhub  = string,
+    resource_group_name  = string,
+    namespace_name       = string
   })
   description = "Namespace and groupname configuration for enrolled payment instrument eventhub"
 }

--- a/src/domains/idpay-app/README.md
+++ b/src/domains/idpay-app/README.md
@@ -43,6 +43,7 @@
 | [azurerm_key_vault_secret.azure_devops_sa_cacrt](https://registry.terraform.io/providers/hashicorp/azurerm/2.99.0/docs/resources/key_vault_secret) | resource |
 | [azurerm_key_vault_secret.azure_devops_sa_token](https://registry.terraform.io/providers/hashicorp/azurerm/2.99.0/docs/resources/key_vault_secret) | resource |
 | [azurerm_key_vault_secret.enrolled_pi_producer_connection_uri](https://registry.terraform.io/providers/hashicorp/azurerm/2.99.0/docs/resources/key_vault_secret) | resource |
+| [azurerm_key_vault_secret.revoked_pi_consumer_connection_uri](https://registry.terraform.io/providers/hashicorp/azurerm/2.99.0/docs/resources/key_vault_secret) | resource |
 | [azurerm_private_dns_a_record.ingress](https://registry.terraform.io/providers/hashicorp/azurerm/2.99.0/docs/resources/private_dns_a_record) | resource |
 | [azurerm_storage_container.idpay_oidc_config](https://registry.terraform.io/providers/hashicorp/azurerm/2.99.0/docs/resources/storage_container) | resource |
 | [helm_release.reloader](https://registry.terraform.io/providers/hashicorp/helm/2.5.1/docs/resources/release) | resource |
@@ -66,7 +67,9 @@
 | [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/2.99.0/docs/data-sources/client_config) | data source |
 | [azurerm_dns_zone.public](https://registry.terraform.io/providers/hashicorp/azurerm/2.99.0/docs/data-sources/dns_zone) | data source |
 | [azurerm_eventhub.enrolled_pi_hub](https://registry.terraform.io/providers/hashicorp/azurerm/2.99.0/docs/data-sources/eventhub) | data source |
+| [azurerm_eventhub.revoked_pi_hub](https://registry.terraform.io/providers/hashicorp/azurerm/2.99.0/docs/data-sources/eventhub) | data source |
 | [azurerm_eventhub_authorization_rule.enrolled_pi_producer_role](https://registry.terraform.io/providers/hashicorp/azurerm/2.99.0/docs/data-sources/eventhub_authorization_rule) | data source |
+| [azurerm_eventhub_authorization_rule.revoked_pi_consumer_role](https://registry.terraform.io/providers/hashicorp/azurerm/2.99.0/docs/data-sources/eventhub_authorization_rule) | data source |
 | [azurerm_key_vault.kv](https://registry.terraform.io/providers/hashicorp/azurerm/2.99.0/docs/data-sources/key_vault) | data source |
 | [azurerm_key_vault_secret.cdn_storage_access_secret](https://registry.terraform.io/providers/hashicorp/azurerm/2.99.0/docs/data-sources/key_vault_secret) | data source |
 | [azurerm_key_vault_secret.pdv_api_key](https://registry.terraform.io/providers/hashicorp/azurerm/2.99.0/docs/data-sources/key_vault_secret) | data source |
@@ -95,7 +98,7 @@
 | <a name="input_env"></a> [env](#input\_env) | n/a | `string` | n/a | yes |
 | <a name="input_env_short"></a> [env\_short](#input\_env\_short) | n/a | `string` | n/a | yes |
 | <a name="input_event_hub_port"></a> [event\_hub\_port](#input\_event\_hub\_port) | n/a | `number` | `9093` | no |
-| <a name="input_eventhub_enrolled_pi"></a> [eventhub\_enrolled\_pi](#input\_eventhub\_enrolled\_pi) | Namespace and groupname configuration for enrolled payment instrument eventhub | <pre>object({<br>    eventhub_name       = string<br>    resource_group_name = string,<br>    namespace_name      = string<br>  })</pre> | n/a | yes |
+| <a name="input_eventhub_pim"></a> [eventhub\_pim](#input\_eventhub\_pim) | Namespace and groupname configuration for enrolled payment instrument eventhub | <pre>object({<br>    enrolled_pi_eventhub = string,<br>    revoked_pi_eventhub  = string,<br>    resource_group_name  = string,<br>    namespace_name       = string<br>  })</pre> | n/a | yes |
 | <a name="input_external_domain"></a> [external\_domain](#input\_external\_domain) | Domain for delegation | `string` | `"pagopa.it"` | no |
 | <a name="input_ingress_load_balancer_hostname"></a> [ingress\_load\_balancer\_hostname](#input\_ingress\_load\_balancer\_hostname) | n/a | `string` | n/a | yes |
 | <a name="input_ingress_load_balancer_ip"></a> [ingress\_load\_balancer\_ip](#input\_ingress\_load\_balancer\_ip) | n/a | `string` | n/a | yes |

--- a/src/domains/idpay-app/env/dev/terraform.tfvars
+++ b/src/domains/idpay-app/env/dev/terraform.tfvars
@@ -54,10 +54,11 @@ enable = {
 }
 
 # Enrolled payment instrument event hub
-eventhub_enrolled_pi = {
-  eventhub_name       = "rtd-enrolled-pi"
-  namespace_name      = "cstar-d-evh-ns"
-  resource_group_name = "cstar-d-msg-rg"
+eventhub_pim = {
+  enrolled_pi_eventhub = "rtd-enrolled-pi"
+  revoked_pi_eventhub  = "rtd-revoked-pi"
+  namespace_name       = "cstar-d-evh-ns"
+  resource_group_name  = "cstar-d-msg-rg"
 }
 
 #

--- a/src/domains/idpay-app/env/uat/terraform.tfvars
+++ b/src/domains/idpay-app/env/uat/terraform.tfvars
@@ -54,8 +54,9 @@ enable = {
 }
 
 # Enrolled payment instrument event hub
-eventhub_enrolled_pi = {
-  eventhub_name       = "rtd-enrolled-pi"
-  namespace_name      = "cstar-u-evh-ns"
-  resource_group_name = "cstar-u-msg-rg"
+eventhub_pim = {
+  enrolled_pi_eventhub = "rtd-enrolled-pi"
+  revoked_pi_eventhub  = "rtd-revoked-pi"
+  namespace_name       = "cstar-u-evh-ns"
+  resource_group_name  = "cstar-u-msg-rg"
 }


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
This PR create a revoke card queue where PIM is the producer and various application (ID PAY) are consumers.

### List of changes
- adds `rtd-revoke-pi` queue to DEV, UAT and PROD environment. (PROD under fa namespace due to limits of rtd evh)
- push to idpay keyvault the connection string as queue consumer 
<!--- Describe your changes in detail -->

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new resources
- [ ] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

Inside `core` folder
`-target="module.event_hub"` for DEV and UAT
`-target="module.event_hub_fa_01"` for PROD -> due to full PROD eventhub namespace

Inside `idpay-app`:
`-target=azurerm_key_vault_secret.revoked_pi_consumer_connection_uri`


<!--- Describe the blocking cause -->
