### PR TITLE
fix: [CSFA-72] Error in "fa_autoscaling_specs" UAT variable

### DIFF
--- a/src/k8s/subscriptions/UAT-CSTAR/terraform.tfvars
+++ b/src/k8s/subscriptions/UAT-CSTAR/terraform.tfvars
@@ -464,7 +464,7 @@ fa_autoscaling_specs = {
       }
     ]
   }
-  famsenrollemnt = {
+  famsenrollment = {
 
     max_replicas = 6
     min_replicas = 1


### PR DESCRIPTION
Fixed a variable name inside object with FA autoscaling specs (only UAT subscription)

### List of changes

- Fixed a variable name inside object with FA autoscaling specs (only UAT subscription)

### Motivation and context
It was necessary to make this fix because otherwise autoscaling on the "famsenrollment" microservice would not work

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No
