### PR TITLE
Requested changes for IOApp Onboarding API

### DIFF
--- a/src/domains/idpay-app/api/idpay_onboarding_workflow/openapi.onboarding.yml
+++ b/src/domains/idpay-app/api/idpay_onboarding_workflow/openapi.onboarding.yml
@@ -71,6 +71,7 @@ paths:
       operationId: onboardingCitizen
       requestBody:
         description: Id of the initiative
+        required: true
         content:
           application/json:
             schema:
@@ -135,6 +136,7 @@ paths:
       operationId: checkPrerequisites
       requestBody:
         description: Id of the iniziative
+        required: true
         content:
           application/json:
             schema:
@@ -214,6 +216,7 @@ paths:
       operationId: consentOnboarding
       requestBody:
         description: 'Unique identifier of the subscribed initiative, flag for PDND acceptation and the list of accepted self-declared criteria'
+        required: true
         content:
           application/json:
             schema:
@@ -345,10 +348,12 @@ components:
         selfDeclarationList:
           type: array
           items:
-            anyOf:
-              - $ref: '#/components/schemas/SelfConsentBoolDTO'
-              - $ref: '#/components/schemas/SelfConsentMultiDTO'
+            $ref: "#/components/schemas/SelfConsentDTO"
           description: The list of accepted self-declared criteria
+    SelfConsentDTO:
+      oneOf:
+        - $ref: '#/components/schemas/SelfConsentBoolDTO'
+        - $ref: '#/components/schemas/SelfConsentMultiDTO'
     OnboardingPutDTO:
       title: OnboardingPutDTO
       type: object
@@ -386,10 +391,12 @@ components:
         selfDeclarationList:
           type: array
           items:
-            anyOf:
-              - $ref: '#/components/schemas/SelfDeclarationBoolDTO'
-              - $ref: '#/components/schemas/SelfDeclarationMultiDTO'
+            $ref: "#/components/schemas/SelfDeclarationDTO"
           description: The list of required self-declared criteria
+    SelfDeclarationDTO:
+      oneOf:
+        - $ref: '#/components/schemas/SelfDeclarationBoolDTO'
+        - $ref: '#/components/schemas/SelfDeclarationMultiDTO'
     PDNDCriteriaDTO:
       type: object
       required:

--- a/src/domains/idpay-app/api/idpay_onboarding_workflow/openapi.onboarding.yml.tpl
+++ b/src/domains/idpay-app/api/idpay_onboarding_workflow/openapi.onboarding.yml.tpl
@@ -71,6 +71,7 @@ paths:
       operationId: onboardingCitizen
       requestBody:
         description: Id of the initiative
+        required: true
         content:
           application/json:
             schema:
@@ -135,6 +136,7 @@ paths:
       operationId: checkPrerequisites
       requestBody:
         description: Id of the iniziative
+        required: true
         content:
           application/json:
             schema:
@@ -214,6 +216,7 @@ paths:
       operationId: consentOnboarding
       requestBody:
         description: 'Unique identifier of the subscribed initiative, flag for PDND acceptation and the list of accepted self-declared criteria'
+        required: true
         content:
           application/json:
             schema:
@@ -345,10 +348,12 @@ components:
         selfDeclarationList:
           type: array
           items:
-            anyOf:
-              - $ref: '#/components/schemas/SelfConsentBoolDTO'
-              - $ref: '#/components/schemas/SelfConsentMultiDTO'
+            $ref: "#/components/schemas/SelfConsentDTO"
           description: The list of accepted self-declared criteria
+    SelfConsentDTO:
+      oneOf:
+        - $ref: '#/components/schemas/SelfConsentBoolDTO'
+        - $ref: '#/components/schemas/SelfConsentMultiDTO'
     OnboardingPutDTO:
       title: OnboardingPutDTO
       type: object
@@ -386,10 +391,12 @@ components:
         selfDeclarationList:
           type: array
           items:
-            anyOf:
-              - $ref: '#/components/schemas/SelfDeclarationBoolDTO'
-              - $ref: '#/components/schemas/SelfDeclarationMultiDTO'
+            $ref: "#/components/schemas/SelfDeclarationDTO"
           description: The list of required self-declared criteria
+    SelfDeclarationDTO:
+      oneOf:
+        - $ref: '#/components/schemas/SelfDeclarationBoolDTO'
+        - $ref: '#/components/schemas/SelfDeclarationMultiDTO'
     PDNDCriteriaDTO:
       type: object
       required:


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes
- Set required for PUT requestBody
- Use oneOf instead of anyOf for type union
- Move oneOf union in a dedicated schema (semantically equal but needed for a limitation of our code generator)

<!--- Describe your changes in detail -->

### Motivation and context

For the oneOf change the reason is:
[oneOf](https://swagger.io/docs/specification/data-models/oneof-anyof-allof-not/#oneof) – validates the value against exactly one of the subschemas
[anyOf](https://swagger.io/docs/specification/data-models/oneof-anyof-allof-not/#anyof) – validates the value against any (one or more) of the subschemas

<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new resources
- [ ] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
