### PR TITLE
chore: [RTD-722] Add revoke producer k8s secret

### DIFF
--- a/src/k8s/README.md
+++ b/src/k8s/README.md
@@ -238,6 +238,7 @@ pre-commit run -a
 | [kubernetes_secret.rtd-enrolled-pi-events-consumer](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/secret) | resource |
 | [kubernetes_secret.rtd-internal-api](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/secret) | resource |
 | [kubernetes_secret.rtd-postgres-credentials](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/secret) | resource |
+| [kubernetes_secret.rtd-revoke-pi-events-producer](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/secret) | resource |
 | [kubernetes_secret.rtd-tkm-write-update-consumer](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/secret) | resource |
 | [kubernetes_secret.rtd-trx-producer](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/secret) | resource |
 | [kubernetes_secret.rtddecrypter](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/secret) | resource |
@@ -257,7 +258,7 @@ pre-commit run -a
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_autoscaling_specs"></a> [autoscaling\_specs](#input\_autoscaling\_specs) | n/a | <pre>map(object({<br>    namespace    = string<br>    min_replicas = number<br>    max_replicas = number<br>    metrics = list(object({<br>      type = string<br>      resource = object({<br>        name = string<br>        target = object({<br>          type                = string<br>          average_utilization = number<br>        })<br>      })<br>    }))<br><br>    }<br>  ))</pre> | n/a | yes |
+| <a name="input_autoscaling_specs"></a> [autoscaling\_specs](#input\_autoscaling\_specs) | n/a | <pre>map(object({<br>    namespace    = string<br>    min_replicas = number<br>    max_replicas = number<br>    metrics = list(object({<br>      type = string<br>      resource = object({<br>        name = string<br>        target = object({<br>          type                = string<br>          average_utilization = number<br>        })<br>      })<br>    }))<br>    }<br>  ))</pre> | n/a | yes |
 | <a name="input_configmaps_bpdmsawardperiod"></a> [configmaps\_bpdmsawardperiod](#input\_configmaps\_bpdmsawardperiod) | n/a | `map(string)` | n/a | yes |
 | <a name="input_configmaps_bpdmsawardwinner"></a> [configmaps\_bpdmsawardwinner](#input\_configmaps\_bpdmsawardwinner) | n/a | `map(string)` | n/a | yes |
 | <a name="input_configmaps_bpdmscitizen"></a> [configmaps\_bpdmscitizen](#input\_configmaps\_bpdmscitizen) | n/a | `map(string)` | n/a | yes |
@@ -294,7 +295,7 @@ pre-commit run -a
 | <a name="input_env_short"></a> [env\_short](#input\_env\_short) | n/a | `string` | n/a | yes |
 | <a name="input_event_hub_port"></a> [event\_hub\_port](#input\_event\_hub\_port) | n/a | `number` | `9093` | no |
 | <a name="input_eventhub_enrolled_pi"></a> [eventhub\_enrolled\_pi](#input\_eventhub\_enrolled\_pi) | n/a | <pre>object({<br>    name                = string,<br>    namespace_name      = string,<br>    resource_group_name = string<br>  })</pre> | n/a | yes |
-| <a name="input_fa_autoscaling_specs"></a> [fa\_autoscaling\_specs](#input\_fa\_autoscaling\_specs) | n/a | <pre>map(object({<br>    min_replicas = number<br>    max_replicas = number<br>    metrics = list(object({<br>      type = string<br>      resource = object({<br>        name = string<br>        target = object({<br>          type                = string<br>          average_utilization = number<br>        })<br>      })<br>    }))<br><br>    }<br>  ))</pre> | n/a | yes |
+| <a name="input_fa_autoscaling_specs"></a> [fa\_autoscaling\_specs](#input\_fa\_autoscaling\_specs) | n/a | <pre>map(object({<br>    min_replicas = number<br>    max_replicas = number<br>    metrics = list(object({<br>      type = string<br>      resource = object({<br>        name = string<br>        target = object({<br>          type                = string<br>          average_utilization = number<br>        })<br>      })<br>    }))<br>    }<br>  ))</pre> | `{}` | no |
 | <a name="input_ingress_load_balancer_ip"></a> [ingress\_load\_balancer\_ip](#input\_ingress\_load\_balancer\_ip) | n/a | `string` | n/a | yes |
 | <a name="input_ingress_replica_count"></a> [ingress\_replica\_count](#input\_ingress\_replica\_count) | n/a | `string` | n/a | yes |
 | <a name="input_k8s_apiserver_host"></a> [k8s\_apiserver\_host](#input\_k8s\_apiserver\_host) | n/a | `string` | n/a | yes |

--- a/src/k8s/rtd_secrets.tf
+++ b/src/k8s/rtd_secrets.tf
@@ -233,6 +233,8 @@ resource "kubernetes_secret" "rtd-revoke-pi-events-producer" {
       local.jaas_config_template_rtd,
       "rtd-revoked-pi",
       "rtd-revoked-pi-producer-policy",
+      var.env_short == "p" ?
+      module.key_vault_secrets_query.values["evh-rtd-revoked-pi-rtd-revoked-pi-producer-policy-key-fa-01"].value :
       module.key_vault_secrets_query.values["evh-rtd-revoked-pi-rtd-revoked-pi-producer-policy-key"].value
     )
   }

--- a/src/k8s/subscriptions/DEV-CSTAR/terraform.tfvars
+++ b/src/k8s/subscriptions/DEV-CSTAR/terraform.tfvars
@@ -470,7 +470,8 @@ secrets_to_be_read_from_kv = [
   "rtd-internal-api-product-subscription-key",
   "mongo-db-connection-uri",
   "evh-rtd-enrolled-pi-rtd-enrolled-pi-consumer-policy-key",
-  "evh-tkm-write-update-token-tkm-write-update-token-sub-key"
+  "evh-tkm-write-update-token-tkm-write-update-token-sub-key",
+  "evh-rtd-revoked-pi-rtd-revoked-pi-producer-policy-key"
 ]
 
 enable = {

--- a/src/k8s/subscriptions/PROD-CSTAR/terraform.tfvars
+++ b/src/k8s/subscriptions/PROD-CSTAR/terraform.tfvars
@@ -662,7 +662,7 @@ secrets_to_be_read_from_kv = [
   "mongo-db-connection-uri",
   "evh-rtd-enrolled-pi-rtd-enrolled-pi-consumer-policy-key",
   "evh-tkm-write-update-token-tkm-write-update-token-sub-key",
-  "evh-rtd-revoked-pi-rtd-revoked-pi-producer-policy-key"
+  "evh-rtd-revoked-pi-rtd-revoked-pi-producer-policy-key-fa-01"
 ]
 
 enable = {

--- a/src/k8s/subscriptions/PROD-CSTAR/terraform.tfvars
+++ b/src/k8s/subscriptions/PROD-CSTAR/terraform.tfvars
@@ -661,7 +661,8 @@ secrets_to_be_read_from_kv = [
   "rtd-internal-api-product-subscription-key",
   "mongo-db-connection-uri",
   "evh-rtd-enrolled-pi-rtd-enrolled-pi-consumer-policy-key",
-  "evh-tkm-write-update-token-tkm-write-update-token-sub-key"
+  "evh-tkm-write-update-token-tkm-write-update-token-sub-key",
+  "evh-rtd-revoked-pi-rtd-revoked-pi-producer-policy-key"
 ]
 
 enable = {

--- a/src/k8s/subscriptions/UAT-CSTAR/terraform.tfvars
+++ b/src/k8s/subscriptions/UAT-CSTAR/terraform.tfvars
@@ -698,7 +698,8 @@ secrets_to_be_read_from_kv = [
   "rtd-internal-api-product-subscription-key",
   "mongo-db-connection-uri",
   "evh-rtd-enrolled-pi-rtd-enrolled-pi-consumer-policy-key",
-  "evh-tkm-write-update-token-tkm-write-update-token-sub-key"
+  "evh-tkm-write-update-token-tkm-write-update-token-sub-key",
+  "evh-rtd-revoked-pi-rtd-revoked-pi-producer-policy-key"
 ]
 
 enable = {

--- a/src/k8s/variables.tf
+++ b/src/k8s/variables.tf
@@ -229,7 +229,6 @@ variable "autoscaling_specs" {
         })
       })
     }))
-
     }
   ))
 }
@@ -248,9 +247,9 @@ variable "fa_autoscaling_specs" {
         })
       })
     }))
-
     }
   ))
+  default = {}
 }
 
 variable "secrets_to_be_read_from_kv" {


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
This PR adds the producer connection string to k8s to be used by PIM to produce revoke events for applications

### List of changes
- added secret to k8s
- fix missing default for fa_autoscale

<!--- Describe your changes in detail -->

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new resources
- [ ] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
