### PR TITLE
[RTD-746] Update APIM Policy to backward support PM-BDP-PIM interaction

### DIFF
--- a/src/k8s/rtd_ingress.tf
+++ b/src/k8s/rtd_ingress.tf
@@ -52,6 +52,17 @@ resource "kubernetes_ingress_v1" "rtd_ingress" {
           path = "/rtdmssenderauth/(.*)"
         }
 
+        path {
+          backend {
+            service {
+              name = "rtd-ms-enrolledpaymentinstrument"
+              port {
+                number = var.default_service_port
+              }
+            }
+          }
+          path = "/enrolledpaymentinstrumentmanager/(.*)"
+        }
       }
     }
   }


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new resources
- [ ] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)
The ingress is missing so apply inside `k8s` folder before
- `-target="kubernetes_ingress_v1.rtd_ingress"`
<!--- Describe the blocking cause -->
