### PR TITLE
fix: fix revoke eventhub connection string fa

### DIFF
--- a/src/k8s/rtd_secrets.tf
+++ b/src/k8s/rtd_secrets.tf
@@ -230,7 +230,7 @@ resource "kubernetes_secret" "rtd-revoke-pi-events-producer" {
       var.env_short == "p" ? "${local.project}-evh-ns-fa-01" : "${local.project}-evh-ns",
     )
     KAFKA_SASL_JAAS_CONFIG_RTD_REVOKED = format(
-      local.jaas_config_template_rtd,
+      var.env_short == "p" ? local.jaas_config_template_fa : local.jaas_config_template_rtd,
       "rtd-revoked-pi",
       "rtd-revoked-pi-producer-policy",
       var.env_short == "p" ?


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
This PR fixs wrong connection string to `rtd-revoked-pi` queue which is created inside fa eventhub ns

### List of changes

<!--- Describe your changes in detail -->

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new resources
- [ ] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
