### PR TITLE
feat: [RTD-812] Add Zendesk action to existing alerts

### DIFF
--- a/src/domains/tae-app/00_monitor.tf
+++ b/src/domains/tae-app/00_monitor.tf
@@ -134,7 +134,7 @@ resource "azurerm_monitor_scheduled_query_rules_alert_v2" "sender_doesnt_send" {
   auto_mitigation_enabled          = false
   workspace_alerts_storage_enabled = false
   description                      = "In the last 24h at least one sender didn't submitted files"
-  display_name                     = "tae-${var.env_short}-a-sender-didnt-send-#ACQ"
+  display_name                     = "${var.domain}-${var.env_short}-a-sender-didnt-send-#ACQ"
   enabled                          = true
   #query_time_range_override        = "PT1H"
   skip_query_validation = false

--- a/src/domains/tae-app/00_monitor.tf
+++ b/src/domains/tae-app/00_monitor.tf
@@ -268,7 +268,7 @@ resource "azurerm_monitor_metric_alert" "tae_azure_data_factory_pipelines_failur
   name                = "${var.domain}-${var.env_short}-adf-pipelines-failures"
   resource_group_name = data.azurerm_resource_group.monitor_rg.name
   scopes              = [data.azurerm_data_factory.datafactory.id]
-  description         = "Triggers whenever at least one pipeline fails."
+  description         = "Triggers whenever at least one pipeline fails #ACQ."
   frequency           = "PT5M"
   window_size         = "PT5M"
   severity            = 1
@@ -283,5 +283,13 @@ resource "azurerm_monitor_metric_alert" "tae_azure_data_factory_pipelines_failur
 
   action {
     action_group_id = azurerm_monitor_action_group.send_to_operations[0].id
+  }
+
+  action {
+    action_group_id = azurerm_monitor_action_group.send_to_zendesk[0].id
+  }
+
+  tags = {
+    key = "Sender Monitoring"
   }
 }

--- a/src/domains/tae-app/00_monitor.tf
+++ b/src/domains/tae-app/00_monitor.tf
@@ -236,12 +236,15 @@ resource "azurerm_monitor_scheduled_query_rules_alert_v2" "sender_auth_missing_i
   auto_mitigation_enabled          = false
   workspace_alerts_storage_enabled = false
   description                      = "Triggers whenever at least one 404 is returned by Sender Auth in response to a request to obtain sender codes associated to a (missing) internal ID."
-  display_name                     = "cstar-${var.env_short}-sender-auth-missing-internal-id"
+  display_name                     = "cstar-${var.env_short}-sender-auth-missing-internal-id-#ACQ"
   enabled                          = true
 
   skip_query_validation = false
   action {
-    action_groups = [azurerm_monitor_action_group.send_to_operations[0].id]
+    action_groups = [
+      azurerm_monitor_action_group.send_to_operations[0].id,
+      azurerm_monitor_action_group.send_to_zendesk[0].id
+    ]
     custom_properties = {
       key  = "value"
       key2 = "value2"

--- a/src/domains/tae-app/00_monitor.tf
+++ b/src/domains/tae-app/00_monitor.tf
@@ -134,12 +134,15 @@ resource "azurerm_monitor_scheduled_query_rules_alert_v2" "sender_doesnt_send" {
   auto_mitigation_enabled          = false
   workspace_alerts_storage_enabled = false
   description                      = "In the last 24h at least one sender didn't submitted files"
-  display_name                     = "a-sender-didnt-send"
+  display_name                     = "tae-${var.env_short}-a-sender-didnt-send-#ACQ"
   enabled                          = true
   #query_time_range_override        = "PT1H"
   skip_query_validation = false
   action {
-    action_groups = [azurerm_monitor_action_group.send_to_operations[0].id]
+    action_groups = [
+      azurerm_monitor_action_group.send_to_operations[0].id,
+      azurerm_monitor_action_group.send_to_zendesk[0].id
+    ]
     custom_properties = {
       key  = "value"
       key2 = "value2"

--- a/src/domains/tae-app/00_monitor.tf
+++ b/src/domains/tae-app/00_monitor.tf
@@ -185,12 +185,15 @@ resource "azurerm_monitor_scheduled_query_rules_alert_v2" "sender_auth_failed_au
   auto_mitigation_enabled          = false
   workspace_alerts_storage_enabled = false
   description                      = "Triggers whenever at least one 401 is returned in response to an unauthorized request to sender auth."
-  display_name                     = "cstar-${var.env_short}-sender-auth-failed-authentications"
+  display_name                     = "cstar-${var.env_short}-sender-auth-failed-authentications-#ACQ"
   enabled                          = true
 
   skip_query_validation = false
   action {
-    action_groups = [azurerm_monitor_action_group.send_to_operations[0].id]
+    action_groups = [
+      azurerm_monitor_action_group.send_to_operations[0].id,
+      azurerm_monitor_action_group.send_to_zendesk[0].id
+    ]
     custom_properties = {
       key  = "value"
       key2 = "value2"


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
This PR proposes to adapt existing alerts in order to send an email to Zendesk as action. 
### List of changes
- add Zendesk action group
- modify display name to include #ACQ string
<!--- Describe your changes in detail -->

### Motivation and context
With this change we can notify Operations' Zendesk also for existing alarms.
<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
