### PR TITLE
feat: [RTD-703] Add file creation in ade/error alert

### DIFF
--- a/src/domains/tae-app/00_monitor.tf
+++ b/src/domains/tae-app/00_monitor.tf
@@ -293,3 +293,71 @@ resource "azurerm_monitor_metric_alert" "tae_azure_data_factory_pipelines_failur
     key = "Sender Monitoring"
   }
 }
+
+resource "azurerm_monitor_scheduled_query_rules_alert_v2" "created_file_in_ade_error" {
+
+  count = var.env_short == "p" ? 1 : 0
+
+  name                = "${var.domain}-${var.env_short}-created-file-in-ade-error"
+  resource_group_name = data.azurerm_resource_group.monitor_rg.name
+  location            = data.azurerm_resource_group.monitor_rg.location
+
+  evaluation_frequency = "PT5M"
+  window_duration      = "PT5M"
+  scopes               = [data.azurerm_log_analytics_workspace.log_analytics.id]
+  severity             = 1
+  criteria {
+    query                   = <<-QUERY
+      let created = StorageBlobLogs
+      | where TimeGenerated > ago(5m)
+      | where AccountName == "cstar${var.env_short}sftp"
+      | where OperationName == "SftpCreate"
+      | where Uri startswith "sftp://cstar${var.env_short}sftp.blob.core.windows.net/ade/error/";
+      let wrote = StorageBlobLogs
+      | where TimeGenerated > ago(5m)
+      | where AccountName == "cstar${var.env_short}sftp"
+      | where OperationName == "SftpWrite"
+      | where Uri startswith "sftp://cstar${var.env_short}sftp.blob.core.windows.net/ade/error/";
+      let committed = StorageBlobLogs
+      | where TimeGenerated > ago(5m)
+      | where AccountName == "cstar${var.env_short}sftp"
+      | where OperationName == "SftpCommit"
+      | where Uri startswith "sftp://cstar${var.env_short}sftp.blob.core.windows.net/ade/error/";
+      created
+      | join kind=inner wrote on Uri
+      | join kind=inner committed on Uri
+      | project Uri
+      QUERY
+    time_aggregation_method = "Count"
+    threshold               = 0
+    operator                = "GreaterThan"
+
+    failing_periods {
+      minimum_failing_periods_to_trigger_alert = 1
+      number_of_evaluation_periods             = 1
+    }
+  }
+
+  auto_mitigation_enabled          = false
+  workspace_alerts_storage_enabled = false
+  description                      = "Triggers whenever at least one file is created through SFTP to the ade/error directory."
+  display_name                     = "${var.domain}-${var.env_short}-created-file-in-ade-error-#ACQ"
+  enabled                          = true
+
+  skip_query_validation = false
+  action {
+    action_groups = [
+      azurerm_monitor_action_group.send_to_operations[0].id,
+      azurerm_monitor_action_group.send_to_zendesk[0].id
+    ]
+    custom_properties = {
+      key  = "value"
+      key2 = "value2"
+    }
+  }
+
+  tags = {
+    key = "Sender Monitoring"
+  }
+}
+

--- a/src/domains/tae-app/README.md
+++ b/src/domains/tae-app/README.md
@@ -45,6 +45,7 @@ No modules.
 | [azurerm_monitor_action_group.send_to_operations](https://registry.terraform.io/providers/hashicorp/azurerm/3.26.0/docs/resources/monitor_action_group) | resource |
 | [azurerm_monitor_action_group.send_to_zendesk](https://registry.terraform.io/providers/hashicorp/azurerm/3.26.0/docs/resources/monitor_action_group) | resource |
 | [azurerm_monitor_metric_alert.tae_azure_data_factory_pipelines_failures](https://registry.terraform.io/providers/hashicorp/azurerm/3.26.0/docs/resources/monitor_metric_alert) | resource |
+| [azurerm_monitor_scheduled_query_rules_alert_v2.created_file_in_ade_error](https://registry.terraform.io/providers/hashicorp/azurerm/3.26.0/docs/resources/monitor_scheduled_query_rules_alert_v2) | resource |
 | [azurerm_monitor_scheduled_query_rules_alert_v2.sender_auth_failed_authentications](https://registry.terraform.io/providers/hashicorp/azurerm/3.26.0/docs/resources/monitor_scheduled_query_rules_alert_v2) | resource |
 | [azurerm_monitor_scheduled_query_rules_alert_v2.sender_auth_missing_internal_id](https://registry.terraform.io/providers/hashicorp/azurerm/3.26.0/docs/resources/monitor_scheduled_query_rules_alert_v2) | resource |
 | [azurerm_monitor_scheduled_query_rules_alert_v2.sender_doesnt_send](https://registry.terraform.io/providers/hashicorp/azurerm/3.26.0/docs/resources/monitor_scheduled_query_rules_alert_v2) | resource |


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
Thi PR proposes to add an alert that triggers whenever a file is created in ade/error directory through SFTP.
### List of changes

<!--- Describe your changes in detail -->
- add alert
- update readme
### Motivation and context

<!--- Why is this change required? What problem does it solve? -->
With this change we can monitor the upload of a file in ade/error and take action contacting Agenzia delle Entrate.
### Type of changes

- [x] Add new resources
- [ ] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
```
--target="azurerm_monitor_scheduled_query_rules_alert_v2.created_file_in_ade_error[0]"
```
---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
