### PR TITLE
feat: [RTD-740] Add ACK ingestor pipeline failure alert

### DIFF
--- a/src/domains/tae-app/00_monitor.tf
+++ b/src/domains/tae-app/00_monitor.tf
@@ -681,7 +681,7 @@ resource "azurerm_monitor_scheduled_query_rules_alert_v2" "ack_ingestor_failures
 
   count = var.env_short == "p" ? 1 : 0
 
-  name                = "${var.domain}-${var.env_short}-ack-ingestor-failures"
+  name                = "${var.domain}-${var.env_short}-adf-ack-ingestor-failures"
   resource_group_name = data.azurerm_resource_group.monitor_rg.name
   location            = data.azurerm_resource_group.monitor_rg.location
 
@@ -709,7 +709,7 @@ resource "azurerm_monitor_scheduled_query_rules_alert_v2" "ack_ingestor_failures
   auto_mitigation_enabled          = false
   workspace_alerts_storage_enabled = false
   description                      = "Triggers whenever at least one ack ingestor pipeline fails."
-  display_name                     = "${var.domain}-${var.env_short}-ack-ingestor-failures-#ACQ"
+  display_name                     = "${var.domain}-${var.env_short}-adf-ack-ingestor-failures-#ACQ"
   enabled                          = true
 
   skip_query_validation = false

--- a/src/domains/tae-app/00_monitor.tf
+++ b/src/domains/tae-app/00_monitor.tf
@@ -573,7 +573,6 @@ resource "azurerm_monitor_scheduled_query_rules_alert_v2" "failed_decryption" {
   }
 }
 
-
 resource "azurerm_monitor_scheduled_query_rules_alert_v2" "no_data_in_decryted_file" {
 
   count = var.env_short == "p" ? 1 : 0
@@ -659,6 +658,58 @@ resource "azurerm_monitor_scheduled_query_rules_alert_v2" "wrong_name_format" {
   workspace_alerts_storage_enabled = false
   description                      = "Triggers whenever at least one input file has a wrong name format (e.g. malformed date)."
   display_name                     = "cstar-${var.env_short}-decrypter-wrong-name-format-#ACQ"
+  enabled                          = true
+
+  skip_query_validation = false
+  action {
+    action_groups = [
+      azurerm_monitor_action_group.send_to_operations[0].id,
+      azurerm_monitor_action_group.send_to_zendesk[0].id
+    ]
+    custom_properties = {
+      key  = "value"
+      key2 = "value2"
+    }
+  }
+
+  tags = {
+    key = "Sender Monitoring"
+  }
+}
+
+resource "azurerm_monitor_scheduled_query_rules_alert_v2" "ack_ingestor_failures" {
+
+  count = var.env_short == "p" ? 1 : 0
+
+  name                = "${var.domain}-${var.env_short}-ack-ingestor-failures"
+  resource_group_name = data.azurerm_resource_group.monitor_rg.name
+  location            = data.azurerm_resource_group.monitor_rg.location
+
+  evaluation_frequency = "PT5M"
+  window_duration      = "PT5M"
+  scopes               = [data.azurerm_log_analytics_workspace.log_analytics.id]
+  severity             = 1
+  criteria {
+    query                   = <<-QUERY
+      AzureDiagnostics
+      | where OperationName == "ack_ingestor - Failed"
+      | where status_s == "Failed"
+      | where pipelineName_s == "ack_ingestor"
+      QUERY
+    time_aggregation_method = "Count"
+    threshold               = 0
+    operator                = "GreaterThan"
+
+    failing_periods {
+      minimum_failing_periods_to_trigger_alert = 1
+      number_of_evaluation_periods             = 1
+    }
+  }
+
+  auto_mitigation_enabled          = false
+  workspace_alerts_storage_enabled = false
+  description                      = "Triggers whenever at least one ack ingestor pipeline fails."
+  display_name                     = "${var.domain}-${var.env_short}-ack-ingestor-failures-#ACQ"
   enabled                          = true
 
   skip_query_validation = false

--- a/src/domains/tae-app/README.md
+++ b/src/domains/tae-app/README.md
@@ -47,6 +47,7 @@ No modules.
 | [azurerm_monitor_action_group.send_to_zendesk](https://registry.terraform.io/providers/hashicorp/azurerm/3.26.0/docs/resources/monitor_action_group) | resource |
 | [azurerm_monitor_diagnostic_setting.acquirer_aggregate_diagnostic_settings](https://registry.terraform.io/providers/hashicorp/azurerm/3.26.0/docs/resources/monitor_diagnostic_setting) | resource |
 | [azurerm_monitor_metric_alert.tae_azure_data_factory_pipelines_failures](https://registry.terraform.io/providers/hashicorp/azurerm/3.26.0/docs/resources/monitor_metric_alert) | resource |
+| [azurerm_monitor_scheduled_query_rules_alert_v2.ack_ingestor_failures](https://registry.terraform.io/providers/hashicorp/azurerm/3.26.0/docs/resources/monitor_scheduled_query_rules_alert_v2) | resource |
 | [azurerm_monitor_scheduled_query_rules_alert_v2.ade_removes_ack_file](https://registry.terraform.io/providers/hashicorp/azurerm/3.26.0/docs/resources/monitor_scheduled_query_rules_alert_v2) | resource |
 | [azurerm_monitor_scheduled_query_rules_alert_v2.created_file_in_ade_error](https://registry.terraform.io/providers/hashicorp/azurerm/3.26.0/docs/resources/monitor_scheduled_query_rules_alert_v2) | resource |
 | [azurerm_monitor_scheduled_query_rules_alert_v2.failed_decryption](https://registry.terraform.io/providers/hashicorp/azurerm/3.26.0/docs/resources/monitor_scheduled_query_rules_alert_v2) | resource |


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
This PR proposes to add an alert that triggers whenever at least one ack ingestor pipeline fails.
### List of changes
- add alert
<!--- Describe your changes in detail -->

### Motivation and context
With this change we can monitor granularly the failure of a specific pipeline.
Troubleshooting activity is aimed and facilitated.
<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [x] Add new resources
- [ ] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
```
--target="azurerm_monitor_scheduled_query_rules_alert_v2.ack_ingestor_failures[0]"
```
---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
