### PR TITLE
fix: [RTD-920] Exclude manual trigger from pipeline failure query for alerts

### DIFF
--- a/src/domains/tae-app/00_monitor.tf
+++ b/src/domains/tae-app/00_monitor.tf
@@ -767,6 +767,7 @@ resource "azurerm_monitor_scheduled_query_rules_alert_v2" "ack_ingestor_failures
       | where OperationName == "ack_ingestor - Failed"
       | where status_s == "Failed"
       | where pipelineName_s == "ack_ingestor"
+      | where todynamic(Predecessors_s)[0]["InvokedByType"] != "Manual"
       QUERY
     time_aggregation_method = "Count"
     threshold               = 0
@@ -820,6 +821,7 @@ resource "azurerm_monitor_scheduled_query_rules_alert_v2" "aggregates_ingestor_f
       | where pipelineName_s == "aggregates_ingestor"
       | where OperationName == "aggregates_ingestor - Failed"
       | where status_s == "Failed"
+      | where todynamic(Predecessors_s)[0]["InvokedByType"] != "Manual"
       QUERY
     time_aggregation_method = "Count"
     threshold               = 0


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
This PR proposes to exclude manual trigger from pipeline failure query for alerts.
### List of changes
- add a condition in query alert
<!--- Describe your changes in detail -->

### Motivation and context
With this change we avoid being alerted for pipeline runs manually triggered.
We take for granted the presence of an operator in those situations, thus an alert is superfluous.
<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [x] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
```
-target=azurerm_monitor_scheduled_query_rules_alert_v2.aggregates_ingestor_failures 
-target=azurerm_monitor_scheduled_query_rules_alert_v2.ack_ingestor_failures
```
---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
