### PR TITLE
fix: [RTD-1091] Change result code in sender auth alert query

### DIFF
--- a/src/domains/tae-app/00_monitor.tf
+++ b/src/domains/tae-app/00_monitor.tf
@@ -227,7 +227,7 @@ resource "azurerm_monitor_scheduled_query_rules_alert_v2" "sender_auth_missing_i
       | where ClientType != "Browser"
       | where AppRoleName == "rtdsenderauth"
       | where OperationName == "GET /sender-code"
-      | where ResultCode == 404
+      | where ResultCode == 401
       QUERY
     time_aggregation_method = "Count"
     threshold               = 0


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
Adapt sender auth alert to query for 401 instead of 404.
### List of changes
- change status code in alert query
<!--- Describe your changes in detail -->

### Motivation and context
We needed this change to adapt alert to new result code returned by sender auth in case of Internal ID miss.
<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information
```
-target=azurerm_monitor_scheduled_query_rules_alert_v2.sender_auth_missing_internal_id
```
<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
