### PR TITLE
feat: [RTD-644] Add header to grant file uniqueness in blob upload policy

### DIFF
--- a/src/core/api/azureblob/azureblob_authorizative_policy.xml
+++ b/src/core/api/azureblob/azureblob_authorizative_policy.xml
@@ -26,6 +26,10 @@
         </when>
       </choose>
 
+      <set-header name="If-None-Match" exists-action="override">
+        <value>*</value>
+      </set-header>
+
     </inbound>
     <backend>
         <base />


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
This PR proposes to add `If-None-Match` header in the policy of encrypted file upload endpoint. 
### List of changes
- add header
<!--- Describe your changes in detail -->

### Motivation and context
With this change we can check if a blob with the same name of the one that is attempted to be uploaded is already present
In case of file name already present in target blob a 409 is returned to the client.
<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [x] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
```
-target=module.api_azureblob
```
---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
