### PR TITLE
chore: [RTD-1069] Add configmap to new aks for ingestor

### DIFF
--- a/src/core/99_outputs.tf
+++ b/src/core/99_outputs.tf
@@ -197,3 +197,10 @@ output "mongo_db_primary_connection_string" {
   description = "Primary mongodb connection string"
   sensitive   = true
 }
+
+# APIM internal subscription key
+output "rtd_internal_api_product_subscription_key" {
+  value       = azurerm_key_vault_secret.rtd_internal_api_product_subscription_key[0].value
+  description = "Subscription key for internal microservices"
+  sensitive   = true
+}

--- a/src/core/README.md
+++ b/src/core/README.md
@@ -455,6 +455,7 @@
 | <a name="output_primary_blob_host"></a> [primary\_blob\_host](#output\_primary\_blob\_host) | Blob storage |
 | <a name="output_primary_web_host"></a> [primary\_web\_host](#output\_primary\_web\_host) | n/a |
 | <a name="output_reverse_proxy_ip"></a> [reverse\_proxy\_ip](#output\_reverse\_proxy\_ip) | n/a |
+| <a name="output_rtd_internal_api_product_subscription_key"></a> [rtd\_internal\_api\_product\_subscription\_key](#output\_rtd\_internal\_api\_product\_subscription\_key) | Subscription key for internal microservices |
 | <a name="output_vnet_address_space"></a> [vnet\_address\_space](#output\_vnet\_address\_space) | n/a |
 | <a name="output_vnet_name"></a> [vnet\_name](#output\_vnet\_name) | n/a |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/src/domains/rtd-app/08_k8s_configmaps.tf
+++ b/src/domains/rtd-app/08_k8s_configmaps.tf
@@ -10,7 +10,7 @@ resource "kubernetes_config_map" "rtd-blob-storage-events-consumer" {
 
   data = {
     KAFKA_TOPIC_BLOB_STORAGE_EVENTS = "rtd-platform-events"
-    KAFKA_BROKER                    = format("%s-evh-ns.servicebus.windows.net:9093", local.product)
+    KAFKA_BROKER                    = "${local.product}-evh-ns.servicebus.windows.net:9093"
   }
 }
 
@@ -73,7 +73,7 @@ resource "kubernetes_config_map" "rtd-tkm-write-update-consumer" {
   data = {
     KAFKA_TOPIC_TKM                = "tkm-write-update-token"
     KAFKA_TOPIC_TKM_CONSUMER_GROUP = "rtd-pim-consumer-group"
-    KAFKA_TOPIC_TKM_BROKER         = format("%s-evh-ns.servicebus.windows.net:9093", local.product)
+    KAFKA_TOPIC_TKM_BROKER         = "${local.product}-evh-ns.servicebus.windows.net:9093"
   }
 }
 
@@ -157,6 +157,6 @@ resource "kubernetes_config_map" "rtdingestor" {
 
   data = {
     JAVA_TOOL_OPTIONS = "-javaagent:/app/applicationinsights-agent.jar"
-    CSV_INGESTOR_HOST = replace(format("apim.internal.%s.cstar.pagopa.it", var.env_short), "..", ".")
+    CSV_INGESTOR_HOST = replace("apim.internal.${var.env}.cstar.pagopa.it", ".prod.", ".")
   }
 }

--- a/src/domains/rtd-app/08_k8s_configmaps.tf
+++ b/src/domains/rtd-app/08_k8s_configmaps.tf
@@ -1,6 +1,31 @@
 #
 # Common kubernetes configmaps. e.g. related to kafka queue
 #
+resource "kubernetes_config_map" "rtd-blob-storage-events-consumer" {
+  count = var.enable.blob_storage_event_grid_integration ? 1 : 0
+  metadata {
+    name      = "rtd-blob-storage-events"
+    namespace = var.domain
+  }
+
+  data = {
+    KAFKA_TOPIC_BLOB_STORAGE_EVENTS = "rtd-platform-events"
+    KAFKA_BROKER                    = format("%s-evh-ns.servicebus.windows.net:9093", local.product)
+  }
+}
+
+resource "kubernetes_secret" "rtd-trx-producer" {
+  count = var.enable.ingestor ? 1 : 0
+  metadata {
+    name      = "rtd-trx-producer"
+    namespace = var.domain
+  }
+
+  data = {
+    KAFKA_TOPIC_RTD_TRX = "rtd-trx"
+  }
+}
+
 resource "kubernetes_config_map" "rtd-pi-from-app-consumer" {
   metadata {
     name      = "rtd-pi-from-app-consumer"
@@ -117,4 +142,21 @@ resource "kubernetes_config_map" "rtdenrolledpaymentinstrument" {
     },
     var.configmaps_rtdenrolledpaymentinstrument
   )
+}
+
+#
+# RTD Ingestor
+#
+resource "kubernetes_config_map" "rtdingestor" {
+  count = var.enable.ingestor ? 1 : 0
+
+  metadata {
+    name      = "rtdingestor"
+    namespace = var.domain
+  }
+
+  data = {
+    JAVA_TOOL_OPTIONS = "-javaagent:/app/applicationinsights-agent.jar"
+    CSV_INGESTOR_HOST = replace(format("apim.internal.%s.cstar.pagopa.it", var.env_short), "..", ".")
+  }
 }

--- a/src/domains/rtd-app/README.md
+++ b/src/domains/rtd-app/README.md
@@ -42,18 +42,21 @@
 | [azurerm_key_vault_secret.event_hub_rtd_jaas_connection_string](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_secret) | resource |
 | [azurerm_private_dns_a_record.ingress](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_dns_a_record) | resource |
 | [helm_release.reloader](https://registry.terraform.io/providers/hashicorp/helm/2.5.1/docs/resources/release) | resource |
+| [kubernetes_config_map.rtd-blob-storage-events-consumer](https://registry.terraform.io/providers/hashicorp/kubernetes/2.11.0/docs/resources/config_map) | resource |
 | [kubernetes_config_map.rtd-pi-from-app-consumer](https://registry.terraform.io/providers/hashicorp/kubernetes/2.11.0/docs/resources/config_map) | resource |
 | [kubernetes_config_map.rtd-pi-to-app-producer](https://registry.terraform.io/providers/hashicorp/kubernetes/2.11.0/docs/resources/config_map) | resource |
 | [kubernetes_config_map.rtd-split-by-pi-consumer](https://registry.terraform.io/providers/hashicorp/kubernetes/2.11.0/docs/resources/config_map) | resource |
 | [kubernetes_config_map.rtd-split-by-pi-producer](https://registry.terraform.io/providers/hashicorp/kubernetes/2.11.0/docs/resources/config_map) | resource |
 | [kubernetes_config_map.rtd-tkm-write-update-consumer](https://registry.terraform.io/providers/hashicorp/kubernetes/2.11.0/docs/resources/config_map) | resource |
 | [kubernetes_config_map.rtdenrolledpaymentinstrument](https://registry.terraform.io/providers/hashicorp/kubernetes/2.11.0/docs/resources/config_map) | resource |
+| [kubernetes_config_map.rtdingestor](https://registry.terraform.io/providers/hashicorp/kubernetes/2.11.0/docs/resources/config_map) | resource |
 | [kubernetes_config_map.rtdpieventprocessor](https://registry.terraform.io/providers/hashicorp/kubernetes/2.11.0/docs/resources/config_map) | resource |
 | [kubernetes_config_map.rtdsenderauth](https://registry.terraform.io/providers/hashicorp/kubernetes/2.11.0/docs/resources/config_map) | resource |
 | [kubernetes_namespace.domain_namespace](https://registry.terraform.io/providers/hashicorp/kubernetes/2.11.0/docs/resources/namespace) | resource |
 | [kubernetes_namespace.system_domain_namespace](https://registry.terraform.io/providers/hashicorp/kubernetes/2.11.0/docs/resources/namespace) | resource |
 | [kubernetes_role_binding.deployer_binding](https://registry.terraform.io/providers/hashicorp/kubernetes/2.11.0/docs/resources/role_binding) | resource |
 | [kubernetes_role_binding.system_deployer_binding](https://registry.terraform.io/providers/hashicorp/kubernetes/2.11.0/docs/resources/role_binding) | resource |
+| [kubernetes_secret.rtd-trx-producer](https://registry.terraform.io/providers/hashicorp/kubernetes/2.11.0/docs/resources/secret) | resource |
 | [kubernetes_service_account.azure_devops](https://registry.terraform.io/providers/hashicorp/kubernetes/2.11.0/docs/resources/service_account) | resource |
 | [azuread_group.adgroup_admin](https://registry.terraform.io/providers/hashicorp/azuread/2.21.0/docs/data-sources/group) | data source |
 | [azuread_group.adgroup_developers](https://registry.terraform.io/providers/hashicorp/azuread/2.21.0/docs/data-sources/group) | data source |

--- a/src/domains/rtd-app/env/prod/terraform.tfvars
+++ b/src/domains/rtd-app/env/prod/terraform.tfvars
@@ -40,12 +40,12 @@ external_domain          = "pagopa.it"
 # Features flags
 #
 enable = {
-  blob_storage_event_grid_integration = false
-  internal_api                        = false
+  blob_storage_event_grid_integration = true
+  internal_api                        = true
   csv_transaction_apis                = false
-  ingestor                            = false
+  ingestor                            = true
   file_register                       = false
-  enrolled_payment_instrument         = false
+  enrolled_payment_instrument         = true
   mongodb_storage                     = false
 }
 #

--- a/src/domains/rtd-common/01_keyvault_external_database.tf
+++ b/src/domains/rtd-common/01_keyvault_external_database.tf
@@ -6,3 +6,10 @@ resource "azurerm_key_vault_secret" "mongo_db_connection_uri" {
   name         = "mongo-db-connection-uri"
   value        = data.terraform_remote_state.core.outputs.mongo_db_primary_connection_string
 }
+
+resource "azurerm_key_vault_secret" "rtd_internal_api_product_subscription_key" {
+
+  key_vault_id = module.key_vault_domain.id
+  name         = "rtd-internal-api-product-subscription-key"
+  value        = data.terraform_remote_state.core.outputs.rtd_internal_api_product_subscription_key
+}

--- a/src/domains/rtd-common/README.md
+++ b/src/domains/rtd-common/README.md
@@ -28,6 +28,7 @@
 | [azurerm_key_vault_access_policy.azdevops_platform_iac_policy](https://registry.terraform.io/providers/hashicorp/azurerm/2.99.0/docs/resources/key_vault_access_policy) | resource |
 | [azurerm_key_vault_secret.mongo_db_connection_uri](https://registry.terraform.io/providers/hashicorp/azurerm/2.99.0/docs/resources/key_vault_secret) | resource |
 | [azurerm_key_vault_secret.rtd_event_hub_jaas_config](https://registry.terraform.io/providers/hashicorp/azurerm/2.99.0/docs/resources/key_vault_secret) | resource |
+| [azurerm_key_vault_secret.rtd_internal_api_product_subscription_key](https://registry.terraform.io/providers/hashicorp/azurerm/2.99.0/docs/resources/key_vault_secret) | resource |
 | [azurerm_monitor_action_group.domain](https://registry.terraform.io/providers/hashicorp/azurerm/2.99.0/docs/resources/monitor_action_group) | resource |
 | [azurerm_private_dns_a_record.data_factory_a_record](https://registry.terraform.io/providers/hashicorp/azurerm/2.99.0/docs/resources/private_dns_a_record) | resource |
 | [azurerm_private_dns_a_record.private_dns_a_record_event_hub_rtd_namespace](https://registry.terraform.io/providers/hashicorp/azurerm/2.99.0/docs/resources/private_dns_a_record) | resource |


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
This PR adds config maps related to rtd-ingestor to new aks.

The `rtd_internal_api_product_subscription_key` secrets is copied to new keyvault by using terraform core folder `outputs`.

### List of changes

<!--- Describe your changes in detail -->

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new resources
- [ ] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
