### PR TITLE
chore: [RTD-1077] update apim file-register address to new aks ingress

### DIFF
--- a/src/core/api/rtd_senderack_correct_download_ack/policy.xml
+++ b/src/core/api/rtd_senderack_correct_download_ack/policy.xml
@@ -4,7 +4,7 @@
     <set-variable name="fileName" value="@(context.Request.MatchedParameters["fileName"])" />
 
     <send-request mode="new" response-variable-name="explicitAckResponse" timeout="60" ignore-error="true">
-      <set-url>@("http://${rtd-ingress-ip}/rtdmsfileregister/sender-ade-ack?filename="+(string)context.Variables["fileName"])</set-url>
+      <set-url>@("${rtd-ingress}/rtdmsfileregister/sender-ade-ack?filename="+(string)context.Variables["fileName"])</set-url>
       <set-method>PUT</set-method>
     </send-request>
 

--- a/src/core/api/rtd_senderack_download_file/azureblob_policy.xml
+++ b/src/core/api/rtd_senderack_download_file/azureblob_policy.xml
@@ -45,7 +45,7 @@
     <outbound>
       <base />
       <send-request mode="new" response-variable-name="senderCode" timeout="60" ignore-error="true">
-        <set-url>@("http://${rtd-ingress-ip}/rtdmsfileregister/file-status")</set-url>
+        <set-url>@("${rtd-ingress}/rtdmsfileregister/file-status")</set-url>
         <set-method>PUT</set-method>
         <set-header name="Content-Type" exists-action="override">
           <value>application/json</value>

--- a/src/core/api/rtd_senderack_filename_list/policy.xml.tpl
+++ b/src/core/api/rtd_senderack_filename_list/policy.xml.tpl
@@ -15,7 +15,7 @@
     <choose>
       <when condition="@(((IResponse)context.Variables["senderCode"]).StatusCode == 200)">
       <!-- join sender codes using "," to obtain sendercode1,sendercode,etc... -->
-        <set-backend-service base-url="http://${rtd-ingress-ip}/rtdmsfileregister" />
+        <set-backend-service base-url="${rtd-ingress}/rtdmsfileregister" />
         <set-query-parameter name="senders" exists-action="override">
           <value>@(string.Join(",", ((IResponse)context.Variables["senderCode"]).Body.As<JArray>()))</value>
         </set-query-parameter>

--- a/src/core/api_rtd.tf
+++ b/src/core/api_rtd.tf
@@ -483,8 +483,7 @@ module "rtd_senderadeack_filename_list" {
   })
 
   xml_content = templatefile("./api/rtd_senderack_filename_list/policy.xml.tpl", {
-    rtd-ingress    = local.ingress_load_balancer_hostname_https
-    rtd-ingress-ip = var.reverse_proxy_ip
+    rtd-ingress = local.ingress_load_balancer_hostname_https
   })
 
   product_ids           = [module.rtd_api_product.product_id]
@@ -516,7 +515,7 @@ module "rtd_senderack_correct_download_ack" {
   subscription_required = true
 
   xml_content = templatefile("./api/rtd_senderack_correct_download_ack/policy.xml", {
-    rtd-ingress-ip = var.reverse_proxy_ip
+    rtd-ingress = local.ingress_load_balancer_hostname_https
   })
 
   product_ids = [module.rtd_api_product.product_id]

--- a/src/core/api_tae.tf
+++ b/src/core/api_tae.tf
@@ -27,8 +27,7 @@ module "rtd_senderack_download_file" {
   subscription_required = true
 
   xml_content = templatefile("./api/rtd_senderack_download_file/azureblob_policy.xml", {
-    rtd-ingress-ip = var.reverse_proxy_ip
-    rtd-ingress    = local.ingress_load_balancer_hostname_https
+    rtd-ingress = local.ingress_load_balancer_hostname_https
   })
 
   product_ids = [module.rtd_api_product.product_id]


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
This PR updates APIM policies which forward request to file-register by using new aks internal address (https)

### List of changes

<!--- Describe your changes in detail -->

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

`-target="module.rtd_senderadeack_filename_list" -target="module.rtd_senderack_correct_download_ack" -target="module.rtd_senderack_download_file"`

<!--- Describe the blocking cause -->
