### PR TITLE
fix: [RTD-1173] Add ip range to filter in aks requests to internal api

### DIFF
--- a/src/core/README.md
+++ b/src/core/README.md
@@ -390,6 +390,7 @@
 | <a name="input_ingress_load_balancer_ip"></a> [ingress\_load\_balancer\_ip](#input\_ingress\_load\_balancer\_ip) | AKS load balancer internal ip. | `string` | n/a | yes |
 | <a name="input_internal_private_domain"></a> [internal\_private\_domain](#input\_internal\_private\_domain) | n/a | `string` | `"internal.cstar.pagopa.it"` | no |
 | <a name="input_k8s_ip_filter_range"></a> [k8s\_ip\_filter\_range](#input\_k8s\_ip\_filter\_range) | n/a | <pre>object({<br>    from = string<br>    to   = string<br>  })</pre> | n/a | yes |
+| <a name="input_k8s_ip_filter_range_aks"></a> [k8s\_ip\_filter\_range\_aks](#input\_k8s\_ip\_filter\_range\_aks) | n/a | <pre>object({<br>    from = string<br>    to   = string<br>  })</pre> | n/a | yes |
 | <a name="input_kubernetes_version"></a> [kubernetes\_version](#input\_kubernetes\_version) | n/a | `string` | `null` | no |
 | <a name="input_law_daily_quota_gb"></a> [law\_daily\_quota\_gb](#input\_law\_daily\_quota\_gb) | The workspace daily quota for ingestion in GB. | `number` | `-1` | no |
 | <a name="input_law_retention_in_days"></a> [law\_retention\_in\_days](#input\_law\_retention\_in\_days) | The workspace data retention in days | `number` | `30` | no |

--- a/src/core/README.md
+++ b/src/core/README.md
@@ -390,7 +390,7 @@
 | <a name="input_ingress_load_balancer_ip"></a> [ingress\_load\_balancer\_ip](#input\_ingress\_load\_balancer\_ip) | AKS load balancer internal ip. | `string` | n/a | yes |
 | <a name="input_internal_private_domain"></a> [internal\_private\_domain](#input\_internal\_private\_domain) | n/a | `string` | `"internal.cstar.pagopa.it"` | no |
 | <a name="input_k8s_ip_filter_range"></a> [k8s\_ip\_filter\_range](#input\_k8s\_ip\_filter\_range) | n/a | <pre>object({<br>    from = string<br>    to   = string<br>  })</pre> | n/a | yes |
-| <a name="input_k8s_ip_filter_range_aks"></a> [k8s\_ip\_filter\_range\_aks](#input\_k8s\_ip\_filter\_range\_aks) | n/a | <pre>object({<br>    from = string<br>    to   = string<br>  })</pre> | n/a | yes |
+| <a name="input_k8s_ip_filter_range_aks"></a> [k8s\_ip\_filter\_range\_aks](#input\_k8s\_ip\_filter\_range\_aks) | AKS IPs range to allow internal APIM usage | <pre>object({<br>    from = string<br>    to   = string<br>  })</pre> | n/a | yes |
 | <a name="input_kubernetes_version"></a> [kubernetes\_version](#input\_kubernetes\_version) | n/a | `string` | `null` | no |
 | <a name="input_law_daily_quota_gb"></a> [law\_daily\_quota\_gb](#input\_law\_daily\_quota\_gb) | The workspace daily quota for ingestion in GB. | `number` | `-1` | no |
 | <a name="input_law_retention_in_days"></a> [law\_retention\_in\_days](#input\_law\_retention\_in\_days) | The workspace data retention in days | `number` | `30` | no |

--- a/src/core/api_product/rtd_api_internal/policy.xml.tpl
+++ b/src/core/api_product/rtd_api_internal/policy.xml.tpl
@@ -20,6 +20,7 @@
     -->
     <ip-filter action="allow">
       <address-range from="${k8s-cluster-ip-range-from}" to="${k8s-cluster-ip-range-to}" />
+      <address-range from="${k8s-cluster-aks-ip-range-from}" to="${k8s-cluster-aks-ip-range-to}"/>
     </ip-filter>
 
     <set-header name="x-user-id" exists-action="override">

--- a/src/core/api_rtd.tf
+++ b/src/core/api_rtd.tf
@@ -38,8 +38,10 @@ module "rtd_api_product_internal" {
   subscriptions_limit = 5
 
   policy_xml = templatefile("./api_product/rtd_api_internal/policy.xml.tpl", {
-    k8s-cluster-ip-range-from = var.k8s_ip_filter_range.from
-    k8s-cluster-ip-range-to   = var.k8s_ip_filter_range.to
+    k8s-cluster-ip-range-from     = var.k8s_ip_filter_range.from
+    k8s-cluster-ip-range-to       = var.k8s_ip_filter_range.to
+    k8s-cluster-aks-ip-range-from = var.k8s_ip_filter_range_aks.from
+    k8s-cluster-aks-ip-range-to   = var.k8s_ip_filter_range_aks.to
   })
 }
 

--- a/src/core/env/dev/terraform.tfvars
+++ b/src/core/env/dev/terraform.tfvars
@@ -829,6 +829,11 @@ k8s_ip_filter_range = {
   to   = "10.1.127.254"
 }
 
+k8s_ip_filter_range_aks = {
+  from = "10.11.0.1"
+  to   = "10.11.127.254"
+}
+
 # This is the k8s ingress controller ip. It must be in the aks subnet range.
 reverse_proxy_ip               = "10.1.0.250"
 ingress_load_balancer_ip       = "10.11.100.250"

--- a/src/core/env/prod/terraform.tfvars
+++ b/src/core/env/prod/terraform.tfvars
@@ -855,6 +855,11 @@ k8s_ip_filter_range = {
   to   = "10.1.127.254"
 }
 
+k8s_ip_filter_range_aks = {
+  from = "10.11.0.1"
+  to   = "10.11.127.254"
+}
+
 redis_sku_name = "Premium"
 redis_family   = "P"
 

--- a/src/core/env/uat/terraform.tfvars
+++ b/src/core/env/uat/terraform.tfvars
@@ -831,6 +831,11 @@ k8s_ip_filter_range = {
   to   = "10.1.127.254"
 }
 
+k8s_ip_filter_range_aks = {
+  from = "10.11.0.1"
+  to   = "10.11.127.254"
+}
+
 # This is the k8s ingress controller ip. It must be in the aks subnet range.
 reverse_proxy_ip               = "10.1.0.250"
 ingress_load_balancer_ip       = "10.11.100.250"

--- a/src/core/variables.tf
+++ b/src/core/variables.tf
@@ -356,6 +356,13 @@ variable "k8s_ip_filter_range" {
   })
 }
 
+variable "k8s_ip_filter_range_aks" {
+  type = object({
+    from = string
+    to   = string
+  })
+}
+
 variable "cstar_support_email" {
   type        = string
   description = "Email for CSTAR support, read by the CSTAR team and Operations team"

--- a/src/core/variables.tf
+++ b/src/core/variables.tf
@@ -357,6 +357,7 @@ variable "k8s_ip_filter_range" {
 }
 
 variable "k8s_ip_filter_range_aks" {
+  description = "AKS IPs range to allow internal APIM usage"
   type = object({
     from = string
     to   = string


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
This PR adds ip range filter to allow requests from new aks cluster
### List of changes

<!--- Describe your changes in detail -->

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new resources
- [ ] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
