### PR TITLE
fix: [RTD-1155] Disable alert on sender doesn't send

### DIFF
--- a/src/domains/tae-app/00_monitor.tf
+++ b/src/domains/tae-app/00_monitor.tf
@@ -136,7 +136,7 @@ resource "azurerm_monitor_scheduled_query_rules_alert_v2" "sender_doesnt_send" {
   workspace_alerts_storage_enabled = false
   description                      = "In the last 24h at least one sender didn't submitted files"
   display_name                     = "${var.domain}-${var.env_short}-a-sender-didnt-send-#ACQ"
-  enabled                          = true
+  enabled                          = false
   #query_time_range_override        = "PT1H"
   skip_query_validation = false
   action {


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
This PR proposes to structurally disable the alert that triggers whenever a sender doesn't send for more than 2 days.
### List of changes

<!--- Describe your changes in detail -->

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new resources
- [ ] Update configuration to existing resources
- [x] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
```
-target=azurerm_monitor_scheduled_query_rules_alert_v2.sender_doesnt_send
```
---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
