### PR TITLE
feat: [IDP-177] Adding group/user lookup table to terraform

### DIFF
--- a/src/domains/idpay-app/api/idpay_timeline/openapi.timeline.yml
+++ b/src/domains/idpay-app/api/idpay_timeline/openapi.timeline.yml
@@ -117,11 +117,7 @@ paths:
             application/json:
               schema:
                 oneOf:
-                  - $ref: '#/components/schemas/TransactionDetailDTO'
-                  - $ref: '#/components/schemas/InstrumentOperationDTO'
-                  - $ref: '#/components/schemas/IbanOperationDTO'
-                  - $ref: '#/components/schemas/OnboardingOperationDTO'
-                  - $ref: '#/components/schemas/RefundOperationDTO'
+                  - $ref: '#/components/schemas/OperationDTO'
         '401':
           description: Authentication failed
           content:
@@ -160,6 +156,13 @@ paths:
                 message: string
 components:
   schemas:
+    OperationDTO:
+      oneOf:
+        - $ref: '#/components/schemas/TransactionDetailDTO'
+        - $ref: '#/components/schemas/InstrumentOperationDTO'
+        - $ref: '#/components/schemas/IbanOperationDTO'
+        - $ref: '#/components/schemas/OnboardingOperationDTO'
+        - $ref: '#/components/schemas/RefundOperationDTO'
     TimelineDTO:
       type: object
       required:

--- a/src/domains/idpay-app/api/idpay_timeline/openapi.timeline.yml
+++ b/src/domains/idpay-app/api/idpay_timeline/openapi.timeline.yml
@@ -116,8 +116,7 @@ paths:
           content:
             application/json:
               schema:
-                oneOf:
-                  - $ref: '#/components/schemas/OperationDTO'
+                $ref: '#/components/schemas/OperationDTO'
         '401':
           description: Authentication failed
           content:

--- a/src/domains/idpay-app/api/idpay_timeline/openapi.timeline.yml.tpl
+++ b/src/domains/idpay-app/api/idpay_timeline/openapi.timeline.yml.tpl
@@ -117,11 +117,7 @@ paths:
             application/json:
               schema:
                 oneOf:
-                  - $ref: '#/components/schemas/TransactionDetailDTO'
-                  - $ref: '#/components/schemas/InstrumentOperationDTO'
-                  - $ref: '#/components/schemas/IbanOperationDTO'
-                  - $ref: '#/components/schemas/OnboardingOperationDTO'
-                  - $ref: '#/components/schemas/RefundOperationDTO'
+                  - $ref: '#/components/schemas/OperationDTO'
         '401':
           description: Authentication failed
           content:
@@ -160,6 +156,13 @@ paths:
                 message: string
 components:
   schemas:
+    OperationDTO:
+      oneOf:
+        - $ref: '#/components/schemas/TransactionDetailDTO'
+        - $ref: '#/components/schemas/InstrumentOperationDTO'
+        - $ref: '#/components/schemas/IbanOperationDTO'
+        - $ref: '#/components/schemas/OnboardingOperationDTO'
+        - $ref: '#/components/schemas/RefundOperationDTO'
     TimelineDTO:
       type: object
       required:

--- a/src/domains/idpay-app/api/idpay_timeline/openapi.timeline.yml.tpl
+++ b/src/domains/idpay-app/api/idpay_timeline/openapi.timeline.yml.tpl
@@ -116,8 +116,7 @@ paths:
           content:
             application/json:
               schema:
-                oneOf:
-                  - $ref: '#/components/schemas/OperationDTO'
+                $ref: '#/components/schemas/OperationDTO'
         '401':
           description: Authentication failed
           content:

--- a/src/domains/idpay-common/.terraform.lock.hcl
+++ b/src/domains/idpay-common/.terraform.lock.hcl
@@ -6,6 +6,7 @@ provider "registry.terraform.io/chilicat/pkcs12" {
   constraints = "0.0.7"
   hashes = [
     "h1:LFd43VGi5SWWP8KX8hkPVmNBk0BBC46nOPEk7qjqMbA=",
+    "h1:YH7CVRfoqapMV0Vra8EXqR1ziOJ54m4dSl0w48tlzkU=",
     "h1:zaF83pVyNkqAL55dZmDJi2yODaQkMyaQr5OLDmTMxeo=",
     "zh:0890343e35d99263280abb8c8e035aa7ae0e201619a134b4a01076b27614124b",
     "zh:13aabd4e1d383990d0bc7520b46710c3774b19bf63cb2e7a1065e6bfea6c91e8",
@@ -28,6 +29,7 @@ provider "registry.terraform.io/hashicorp/azuread" {
   version     = "2.21.0"
   constraints = "2.21.0"
   hashes = [
+    "h1:9gG6SWoUZZmmXbYBv6ra2RF5NYpamB9tGjsuBxrasFQ=",
     "h1:akcofWscEl0ecIbf7lyEqRvPfOdA5q75EZvK8uSum1c=",
     "h1:qHYbB6LJsYPVUcd7QkZ5tU+IX+10VcUG4NzsmIuWdlE=",
     "zh:18c56e0478e8b3849f6d52f7e0ee495538e7fce66f22fc84a79599615e50ad1c",
@@ -50,6 +52,7 @@ provider "registry.terraform.io/hashicorp/azurerm" {
   constraints = ">= 2.80.0, 2.99.0, <= 2.99.0"
   hashes = [
     "h1:/ZY1j8YgB5GeqPnjT8avyRFjUcGH3rCk1xGLKcUCtWc=",
+    "h1:FXBB5TkvZpZA+ZRtofPvp5IHZpz4Atw7w9J8GDgMhvk=",
     "h1:aCGPSDzEWQZLeWmUeSnXA6sDHMumbDqOVdSVKVziYoE=",
     "zh:08d81e72e97351538ab4d15548942217bf0c4d3b79ad3f4c95d8f07f902d2fa6",
     "zh:11fdfa4f42d6b6f01371f336fea56f28a1db9e7b490c5ca0b352f6bbca5a27f1",
@@ -67,9 +70,10 @@ provider "registry.terraform.io/hashicorp/azurerm" {
 
 provider "registry.terraform.io/hashicorp/null" {
   version     = "3.1.1"
-  constraints = ">= 3.0.0, 3.1.1"
+  constraints = ">= 3.0.0, 3.1.1, <= 3.2.0"
   hashes = [
     "h1:1J3nqAREzuaLE7x98LEELCCaMV6BRiawHSg9MmFvfQo=",
+    "h1:71sNUDvmiJcijsvfXpiLCz0lXIBSsEJjMxljt7hxMhw=",
     "h1:Pctug/s/2Hg5FJqjYcTM0kPyx3AoYK1MpRWO0T9V2ns=",
     "zh:063466f41f1d9fd0dd93722840c1314f046d8760b1812fa67c34de0afcba5597",
     "zh:08c058e367de6debdad35fc24d97131c7cf75103baec8279aba3506a08b53faf",

--- a/src/domains/idpay-common/03_database.tf
+++ b/src/domains/idpay-common/03_database.tf
@@ -409,14 +409,17 @@ locals {
           unique = false
         },
         {
-          keys   = ["userId"]
-          unique = false
-        },
-        {
           keys   = ["initiativeId"]
           unique = false
         },
       ]
+    },
+    {
+      name = "custom_sequence"
+      indexes = [{
+        keys   = ["_id"]
+        unique = true
+      }]
     },
   ]
 }

--- a/src/domains/idpay-common/03_database.tf
+++ b/src/domains/idpay-common/03_database.tf
@@ -412,6 +412,10 @@ locals {
           keys   = ["userId"]
           unique = false
         },
+        {
+          keys   = ["initiativeId"]
+          unique = false
+        },
       ]
     },
   ]

--- a/src/domains/idpay-common/03_database.tf
+++ b/src/domains/idpay-common/03_database.tf
@@ -398,6 +398,22 @@ locals {
         },
       ]
     },
+    {
+      name = "group_user_whitelist"
+      indexes = [{
+        keys   = ["_id"]
+        unique = true
+        },
+        {
+          keys   = ["groupId"]
+          unique = false
+        },
+        {
+          keys   = ["userId"]
+          unique = false
+        },
+      ]
+    },
   ]
 }
 

--- a/src/domains/tae-common/04_datafactory.tf
+++ b/src/domains/tae-common/04_datafactory.tf
@@ -22,7 +22,7 @@ resource "azurerm_data_factory" "data_factory" {
 
 resource "azurerm_data_factory_integration_runtime_azure" "autoresolve" {
   name                    = "AutoResolveIntegrationRuntime"
-  resource_group_name     = azurerm_resource_group.data_factory_rg.name 
+  resource_group_name     = azurerm_resource_group.data_factory_rg.name
   data_factory_id         = azurerm_data_factory.data_factory.id
   location                = "AutoResolve"
   virtual_network_enabled = true

--- a/src/domains/tae-common/README.md
+++ b/src/domains/tae-common/README.md
@@ -22,6 +22,7 @@
 | [azurerm_cosmosdb_sql_container.aggregates](https://registry.terraform.io/providers/hashicorp/azurerm/2.99.0/docs/resources/cosmosdb_sql_container) | resource |
 | [azurerm_cosmosdb_sql_database.transaction_aggregate](https://registry.terraform.io/providers/hashicorp/azurerm/2.99.0/docs/resources/cosmosdb_sql_database) | resource |
 | [azurerm_data_factory.data_factory](https://registry.terraform.io/providers/hashicorp/azurerm/2.99.0/docs/resources/data_factory) | resource |
+| [azurerm_data_factory_integration_runtime_azure.autoresolve](https://registry.terraform.io/providers/hashicorp/azurerm/2.99.0/docs/resources/data_factory_integration_runtime_azure) | resource |
 | [azurerm_data_factory_managed_private_endpoint.managed_pe](https://registry.terraform.io/providers/hashicorp/azurerm/2.99.0/docs/resources/data_factory_managed_private_endpoint) | resource |
 | [azurerm_key_vault_access_policy.ad_admin_group_policy](https://registry.terraform.io/providers/hashicorp/azurerm/2.99.0/docs/resources/key_vault_access_policy) | resource |
 | [azurerm_key_vault_access_policy.adgroup_developers_policy](https://registry.terraform.io/providers/hashicorp/azurerm/2.99.0/docs/resources/key_vault_access_policy) | resource |


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

Added group_user_whitelist collection to IDPay database. The collection features two additional non-unique indexes (apart from the default unique _id): one on the groupId field, and another one on the userId field

### Motivation and context

This lookup collection has been added in order to prevent large (about > 90K userId) whitelists of userId strings to be written on a single document of the group collection, causing a 413 error, and a subsequent exception. 

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
