### PR TITLE
chore: [RTD-1302] ignore changes on aggregates db max throughput

### DIFF
--- a/src/domains/idpay-app/README.md
+++ b/src/domains/idpay-app/README.md
@@ -151,6 +151,7 @@
 | <a name="input_mail_server_port"></a> [mail\_server\_port](#input\_mail\_server\_port) | SMTP server port | `string` | `"587"` | no |
 | <a name="input_monitor_resource_group_name"></a> [monitor\_resource\_group\_name](#input\_monitor\_resource\_group\_name) | Monitor resource group name | `string` | n/a | yes |
 | <a name="input_p7m_cert_validity_hours"></a> [p7m\_cert\_validity\_hours](#input\_p7m\_cert\_validity\_hours) | n/a | `number` | `87600` | no |
+| <a name="input_pdv_timeout_sec"></a> [pdv\_timeout\_sec](#input\_pdv\_timeout\_sec) | PDV timeout (sec) | `number` | `15` | no |
 | <a name="input_pdv_tokenizer_url"></a> [pdv\_tokenizer\_url](#input\_pdv\_tokenizer\_url) | PDV uri. Endpoint for encryption of pii information. | `string` | `"127.0.0.1"` | no |
 | <a name="input_pm_backend_url"></a> [pm\_backend\_url](#input\_pm\_backend\_url) | Payment manager backend url (enrollment) | `string` | n/a | yes |
 | <a name="input_pm_service_base_url"></a> [pm\_service\_base\_url](#input\_pm\_service\_base\_url) | PM Service uri. Endpoint to retrieve Payment Instruments information. | `string` | `"127.0.0.1"` | no |

--- a/src/domains/tae-common/03_database.tf
+++ b/src/domains/tae-common/03_database.tf
@@ -54,8 +54,14 @@ resource "azurerm_cosmosdb_sql_database" "transaction_aggregate" {
   dynamic "autoscale_settings" {
     for_each = var.cosmos_db_aggregates_params.enable_autoscaling && !var.cosmos_db_aggregates_params.enable_serverless ? [""] : []
     content {
-      max_throughput = var.cosmos_db_aggregates_params.max_throughput
+      max_throughput = var.cosmos_db_aggregates_params.max_throughput # override via portal
     }
+  }
+
+  lifecycle {
+    ignore_changes = [
+      autoscale_settings
+    ]
   }
 }
 
@@ -72,8 +78,14 @@ resource "azurerm_cosmosdb_sql_container" "aggregates" {
   dynamic "autoscale_settings" {
     for_each = var.cosmos_db_aggregates_params.enable_autoscaling && !var.cosmos_db_aggregates_params.enable_serverless ? [""] : []
     content {
-      max_throughput = var.cosmos_db_aggregates_params.max_throughput
+      max_throughput = var.cosmos_db_aggregates_params.max_throughput # override via portal
     }
+  }
+
+  lifecycle {
+    ignore_changes = [
+      autoscale_settings
+    ]
   }
 
   default_ttl = -1


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
This PR proposes to ignore the change on max throughput for cosmos aggregates resource. As adopted practice, it's suggested to change the max throughput setting via portal.

### List of changes

<!--- Describe your changes in detail -->
- Add snippet to ignore max throughput setting on aggregates db

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new resources
- [ ] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [X] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [X] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
