### PR TITLE
chore: [RTD-1305] upgrade rtd-platform-events queue partitions and add server side retry cosmos db

### DIFF
--- a/src/core/env/dev/terraform.tfvars
+++ b/src/core/env/dev/terraform.tfvars
@@ -370,7 +370,7 @@ dns_storage_account_tkm = {
 cosmos_mongo_db_params = {
   enabled      = true
   kind         = "MongoDB"
-  capabilities = ["EnableMongo"]
+  capabilities = ["EnableMongo", "DisableRateLimitingResponses"]
   offer_type   = "Standard"
   consistency_policy = {
     consistency_level       = "BoundedStaleness"
@@ -621,7 +621,7 @@ eventhubs = [
   },
   {
     name              = "rtd-platform-events"
-    partitions        = 1
+    partitions        = 4
     message_retention = 1
     consumers         = ["rtd-decrypter-consumer-group", "rtd-ingestor-consumer-group", "rtd-file-register-consumer-group"]
     keys = [


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes
It was changed the number of partitions for rtd-platform-events queue and it was added a capability to cosmos db to enable server side retry.

<!--- Describe your changes in detail -->

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
