### PR TITLE
feat: [RTD-1330] Add EURON fiscal code mapping

### DIFF
--- a/src/core/api/rtd_abi_to_fiscalcode/policy.xml.tpl
+++ b/src/core/api/rtd_abi_to_fiscalcode/policy.xml.tpl
@@ -13,7 +13,8 @@
           new JProperty("SUMUP", "IE9813461A"),
           new JProperty("ICARD", "BG175325806"),
           new JProperty("TPAY1", "09771701001"),
-          new JProperty("AMAZN", "97898850157")
+          new JProperty("AMAZN", "97898850157"),
+          new JProperty("EURON", "DE182769455")
         ).ToString();
         }
       </set-body>

--- a/src/core/api_rtd.tf
+++ b/src/core/api_rtd.tf
@@ -437,7 +437,7 @@ module "rtd_fake_abi_to_fiscal_code" {
 
   source = "git::https://github.com/pagopa/azurerm.git//api_management_api?ref=v2.16.0"
 
-  name                = format("%s-rtd-fake-abi-to-fiscal-code", var.env_short)
+  name                = "${var.env_short}-rtd-fake-abi-to-fiscal-code"
   api_management_name = module.apim.name
   resource_group_name = azurerm_resource_group.rg_api.name
 


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
This PR proposes to add Euronet technical sender code (EURON) to Fiscal Code mapping.
### List of changes
- add mapping to the endpoint exposed to the Batch Service.
<!--- Describe your changes in detail -->

### Motivation and context
This change allow Euronet to use their technical ABI and grants AdE the corresponding Fiscal Code if the same value is used in acquirer code field.
<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [x] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
```
-target=module.rtd_fake_abi_to_fiscal_code
```
---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
