### PR TITLE
feat: IDP-367 added capability DisableRateLimitingResponses to cosmos

### DIFF
--- a/src/domains/idpay-common/env/dev/terraform.tfvars
+++ b/src/domains/idpay-common/env/dev/terraform.tfvars
@@ -36,7 +36,7 @@ rtd_keyvault = {
 
 cosmos_mongo_db_params = {
   enabled      = true
-  capabilities = ["EnableMongo", "EnableServerless"]
+  capabilities = ["EnableMongo", "EnableServerless", "DisableRateLimitingResponses"]
   offer_type   = "Standard"
   consistency_policy = {
     consistency_level       = "Strong"

--- a/src/domains/idpay-common/env/prod/terraform.tfvars
+++ b/src/domains/idpay-common/env/prod/terraform.tfvars
@@ -36,7 +36,7 @@ rtd_keyvault = {
 
 cosmos_mongo_db_params = {
   enabled      = true
-  capabilities = ["EnableMongo"]
+  capabilities = ["EnableMongo", "DisableRateLimitingResponses"]
   offer_type   = "Standard"
   consistency_policy = {
     consistency_level       = "Strong"

--- a/src/domains/idpay-common/env/uat/terraform.tfvars
+++ b/src/domains/idpay-common/env/uat/terraform.tfvars
@@ -36,7 +36,7 @@ rtd_keyvault = {
 
 cosmos_mongo_db_params = {
   enabled      = true
-  capabilities = ["EnableMongo", "EnableServerless"]
+  capabilities = ["EnableMongo", "EnableServerless", "DisableRateLimitingResponses"]
   offer_type   = "Standard"
   consistency_policy = {
     consistency_level       = "Strong"


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### **!!!Be carefull with this PR!!!**
The provider 2.99 of Azure will destroy and create the cosmosdb_account, while the change performed doen't require it (new versions also allow to change this without destroy).

Please, apply the change manually, next verify that planning on the merge will not see any change on the infrastructure

To apply manually you have to:

1. open the Azure portal
2. locate and open the _cstar-[ENVSHORT]-idpay-mongodb-account_ resource
3. go to Features blade
4. Enable "Server Side Retry"




*********

### List of changes

IDP-367 added capability DisableRateLimitingResponses to cosmos

<!--- Describe your changes in detail -->

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [x] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
