### PR TITLE
fix: [RTD-1384] Fix deposit on ade/error alert

### DIFF
--- a/src/domains/tae-app/00_monitor.tf
+++ b/src/domains/tae-app/00_monitor.tf
@@ -282,18 +282,12 @@ resource "azurerm_monitor_scheduled_query_rules_alert_v2" "created_file_in_ade_e
       | where AccountName == "cstar${var.env_short}sftp"
       | where OperationName == "SftpCreate"
       | where Uri startswith "sftp://cstar${var.env_short}sftp.blob.core.windows.net/ade/error/";
-      let wrote = StorageBlobLogs
-      | where TimeGenerated > ago(5m)
-      | where AccountName == "cstar${var.env_short}sftp"
-      | where OperationName == "SftpWrite"
-      | where Uri startswith "sftp://cstar${var.env_short}sftp.blob.core.windows.net/ade/error/";
       let committed = StorageBlobLogs
       | where TimeGenerated > ago(5m)
       | where AccountName == "cstar${var.env_short}sftp"
       | where OperationName == "SftpCommit"
       | where Uri startswith "sftp://cstar${var.env_short}sftp.blob.core.windows.net/ade/error/";
       created
-      | join kind=inner wrote on Uri
       | join kind=inner committed on Uri
       | project Uri
       QUERY


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
This PR proposes to change the query used to alert on ade/error file deposit.
### List of changes
- remove temporary wrote table.
<!--- Describe your changes in detail -->

### Motivation and context
The creation of an empty file in SFTP skips the write step, thus the join on create/write/commit tables would result in no row to alert.
With this change we exclude the write step from the join. Now even the creation an empty file is alerted correctly.
<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
```
-target=azurerm_monitor_scheduled_query_rules_alert_v2.created_file_in_ade_error
```
---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
