### PR TITLE
fix: [RTD-1402] Update OpenAPI with error status for rejected PUT

### DIFF
--- a/src/core/api/azureblob/openapi.json.tpl
+++ b/src/core/api/azureblob/openapi.json.tpl
@@ -34,7 +34,13 @@
                 "responses": {
                     "200": {
                         "description": null
-                    }
+                    },
+                     "400": {
+                         "description": "Content-Length is 0"
+                     },
+                     "413": {
+                         "description": "Content-Length exceeds ${pgp-put-limit-bytes}"
+                     }
                 }
             },
             "delete": {

--- a/src/core/api_rtd.tf
+++ b/src/core/api_rtd.tf
@@ -65,7 +65,8 @@ module "api_azureblob" {
 
   content_format = "openapi"
   content_value = templatefile("./api/azureblob/openapi.json.tpl", {
-    host = azurerm_api_management_custom_domain.api_custom_domain.proxy[0].host_name
+    host                = azurerm_api_management_custom_domain.api_custom_domain.proxy[0].host_name
+    pgp-put-limit-bytes = var.pgp_put_limit_bytes
   })
 
   xml_content = file("./api/base_policy.xml")
@@ -421,7 +422,8 @@ module "rtd_blob_internal" {
 
   content_format = "openapi"
   content_value = templatefile("./api/azureblob/internal.openapi.json.tpl", {
-    host = azurerm_api_management_custom_domain.api_custom_domain.proxy[0].host_name
+    host = azurerm_api_management_custom_domain.api_custom_domain.proxy[0].host_name,
+
   })
 
   subscription_required = true


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
This PR proposes to update the OpenAPI of Blob Storage endpoint with PUT limit status codes.
### List of changes
- update OpenAPI file.
<!--- Describe your changes in detail -->

### Motivation and context
With this change we can provide users information about possible status codes returned by the endpoint.
<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
```
-target=module.api_azureblob
```
<img width="878" alt="image" src="https://user-images.githubusercontent.com/12004943/221196589-cd5bae43-eec6-41bc-9de6-cd10762c89fd.png">

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
