### PR TITLE
feat: [RTD-1475] Log Content-Length header in PGP upload endpoint

### DIFF
--- a/src/core/README.md
+++ b/src/core/README.md
@@ -592,6 +592,7 @@
 
 | Name | Type |
 |------|------|
+| [azurerm_api_management_api_diagnostic.blob_storage_api_diagnostic](https://registry.terraform.io/providers/hashicorp/azurerm/2.99.0/docs/resources/api_management_api_diagnostic) | resource |
 | [azurerm_api_management_api_diagnostic.rtd_csv_transaction_diagnostic](https://registry.terraform.io/providers/hashicorp/azurerm/2.99.0/docs/resources/api_management_api_diagnostic) | resource |
 | [azurerm_api_management_api_version_set.bpd_io_award_period](https://registry.terraform.io/providers/hashicorp/azurerm/2.99.0/docs/resources/api_management_api_version_set) | resource |
 | [azurerm_api_management_api_version_set.bpd_io_citizen](https://registry.terraform.io/providers/hashicorp/azurerm/2.99.0/docs/resources/api_management_api_version_set) | resource |

--- a/src/core/api_rtd.tf
+++ b/src/core/api_rtd.tf
@@ -406,6 +406,29 @@ resource "azurerm_api_management_api_diagnostic" "rtd_csv_transaction_diagnostic
   }
 }
 
+resource "azurerm_api_management_api_diagnostic" "blob_storage_api_diagnostic" {
+  count = var.enable.rtd.csv_transaction_apis ? 1 : 0
+
+  identifier               = "applicationinsights"
+  resource_group_name      = azurerm_resource_group.rg_api.name
+  api_management_name      = module.apim.name
+  api_name                 = format("%s-azureblob", var.env_short)
+  api_management_logger_id = module.apim.logger_id
+
+  sampling_percentage       = 100.0
+  always_log_errors         = true
+  log_client_ip             = true
+  verbosity                 = "information"
+  http_correlation_protocol = "W3C"
+
+  frontend_request {
+    body_bytes = 0
+    headers_to_log = [
+      "Content-Length"
+    ]
+  }
+}
+
 ## RTD CSV Transaction Decrypted API ##
 module "rtd_blob_internal" {
   count  = var.enable.rtd.internal_api ? 1 : 0


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
This PR proposes to terraform the log of Content-Length header.
### List of changes
- add API diagnostic to blob storage endpoint.
<!--- Describe your changes in detail -->

### Motivation and context
With this change we terraform a change done through Azure Portal.
With the log of the header we can be notified if something with the header is wrong.
<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [x] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

#### Has This Been Tested?

- [x] Yes
- [ ] No

### Other information
Target: 
```
azurerm_api_management_api_diagnostic.blob_storage_api_diagnostic
```

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] Unit Test Suite
- [ ] Integration Test Suite
- [ ] Api Tests
- [ ] Load Tests

<!-- Provide screenshot or link to test results-->
No changes are proposed after resource import:
<img width="482" alt="image" src="https://user-images.githubusercontent.com/12004943/224082073-b5129128-c90f-4f27-861c-b9db61feb210.png">
The header log is active:
![image](https://user-images.githubusercontent.com/12004943/224082227-e9638b53-c999-422a-a71c-0e6b962274c3.png)

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
