### PR TITLE
fix: [RTD-1476] Remove service unavailable from catch-all alert

### DIFF
--- a/src/domains/tae-app/00_monitor.tf
+++ b/src/domains/tae-app/00_monitor.tf
@@ -342,8 +342,8 @@ resource "azurerm_monitor_scheduled_query_rules_alert_v2" "sender_fails_blob_upl
       | where TimeGenerated > ago(5m)
       | where requestUri_s startswith "/pagopastorage/"
       | where httpMethod_s == "PUT"
-      | where httpStatus_d !in (201, 400, 409, 413)
-      | project TimeGenerated, Filename = substring(requestUri_s, 77, 47), Container = substring(requestUri_s, 15, 61)
+      | where httpStatus_d !in (201, 400, 409, 413, 503)
+      | project TimeGenerated, Filename = substring(requestUri_s, 77, 47), Container = substring(requestUri_s, 15, 61),  httpStatus_d
       QUERY
     time_aggregation_method = "Count"
     threshold               = 0


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
This PR proposes to remove 503 Service Unavailable from catch-all alert on pgp upload.
### List of changes
- exclude 503 from query results
- add status code to query results for clarity
<!--- Describe your changes in detail -->

### Motivation and context
With this change we avoid 2 alerts for the same event.
We also add additional information to the returned results.
<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

#### Has This Been Tested?

- [x] Yes
- [ ] No

### Other information
Target: 
```
azurerm_monitor_scheduled_query_rules_alert_v2.sender_fails_blob_upload
```

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] Unit Test Suite
- [ ] Integration Test Suite
- [ ] Api Tests
- [ ] Load Tests

<!-- Provide screenshot or link to test results-->
The alert is updated:
![Pasted_Image_09_03_23__17_10](https://user-images.githubusercontent.com/12004943/224084202-98b6a126-c6a3-4532-8191-e21c8f2a9c13.png)


<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
