### PR TITLE
add developers group to mil product

### DIFF
--- a/src/domains/idpay-app/04_apim_api_mil.tf
+++ b/src/domains/idpay-app/04_apim_api_mil.tf
@@ -20,6 +20,8 @@ module "idpay_api_mil_product" {
 
   policy_xml = file("./api_product/mil_api/policy_mil.xml")
 
+  groups = ["developers"]
+
 }
 
 ## IDPAY MIL API ##


### PR DESCRIPTION
In order to view MIL product to any (developer) API users, this PR assign group Developers to the MIL Product 
