### PR TITLE
fix: IDP-1260 setting PROD storage private

### DIFF
--- a/src/domains/idpay-app/09_audit_log_storage.tf
+++ b/src/domains/idpay-app/09_audit_log_storage.tf
@@ -36,6 +36,32 @@ module "idpay_audit_storage" {
   tags = var.tags
 }
 
+resource "azurerm_private_endpoint" "idpay_audit_storage_private_endpoint" {
+
+  name                = "${local.product}-audit-storage-private-endpoint"
+  location            = var.location
+  resource_group_name = data.azurerm_log_analytics_workspace.log_analytics.resource_group_name
+  subnet_id           = data.azurerm_subnet.private_endpoint_subnet.id
+
+  private_dns_zone_group {
+    name                 = "${local.product}-audit-storage-private-dns-zone-group"
+    private_dns_zone_ids = [data.azurerm_private_dns_zone.storage_account.id]
+  }
+
+  private_service_connection {
+    name                           = "${local.product}-audit-storage-private-service-connection"
+    private_connection_resource_id = module.idpay_audit_storage.id
+    is_manual_connection           = false
+    subresource_names              = ["blob"]
+  }
+
+  tags = var.tags
+
+  depends_on = [
+    module.idpay_audit_storage
+  ]
+}
+
 
 # Set legal hold on container created by azure monitor with the data exporter (the name is fixed and definid by the exporter)
 resource "null_resource" "idpay_audit_lh" {

--- a/src/domains/idpay-app/09_refund_storage.tf
+++ b/src/domains/idpay-app/09_refund_storage.tf
@@ -27,6 +27,32 @@ module "idpay_refund_storage" {
   tags = var.tags
 }
 
+resource "azurerm_private_endpoint" "idpay_refund_storage_private_endpoint" {
+
+  name                = "${local.product}-refund-storage-private-endpoint"
+  location            = var.location
+  resource_group_name = azurerm_resource_group.rg_refund_storage.name
+  subnet_id           = data.azurerm_subnet.private_endpoint_subnet.id
+
+  private_dns_zone_group {
+    name                 = "${local.product}-refund-storage-private-dns-zone-group"
+    private_dns_zone_ids = [data.azurerm_private_dns_zone.storage_account.id]
+  }
+
+  private_service_connection {
+    name                           = "${local.product}-refund-storage-private-service-connection"
+    private_connection_resource_id = module.idpay_refund_storage.id
+    is_manual_connection           = false
+    subresource_names              = ["blob"]
+  }
+
+  tags = var.tags
+
+  depends_on = [
+    module.idpay_refund_storage
+  ]
+}
+
 resource "azurerm_storage_container" "idpay_refund_container" {
   name                  = "refund"
   storage_account_name  = module.idpay_refund_storage.name

--- a/src/domains/idpay-app/README.md
+++ b/src/domains/idpay-app/README.md
@@ -121,7 +121,9 @@
 | [azurerm_monitor_scheduled_query_rules_alert_v2.CreateTransaction](https://registry.terraform.io/providers/hashicorp/azurerm/3.40.0/docs/resources/monitor_scheduled_query_rules_alert_v2) | resource |
 | [azurerm_monitor_scheduled_query_rules_alert_v2.RewardOutcomeFile](https://registry.terraform.io/providers/hashicorp/azurerm/3.40.0/docs/resources/monitor_scheduled_query_rules_alert_v2) | resource |
 | [azurerm_private_dns_a_record.ingress](https://registry.terraform.io/providers/hashicorp/azurerm/3.40.0/docs/resources/private_dns_a_record) | resource |
+| [azurerm_private_endpoint.idpay_audit_storage_private_endpoint](https://registry.terraform.io/providers/hashicorp/azurerm/3.40.0/docs/resources/private_endpoint) | resource |
 | [azurerm_private_endpoint.idpay_initiative_storage_private_endpoint](https://registry.terraform.io/providers/hashicorp/azurerm/3.40.0/docs/resources/private_endpoint) | resource |
+| [azurerm_private_endpoint.idpay_refund_storage_private_endpoint](https://registry.terraform.io/providers/hashicorp/azurerm/3.40.0/docs/resources/private_endpoint) | resource |
 | [azurerm_resource_group.rg_refund_storage](https://registry.terraform.io/providers/hashicorp/azurerm/3.40.0/docs/resources/resource_group) | resource |
 | [azurerm_role_assignment.event_grid_sender_role_on_refund_storage_topic](https://registry.terraform.io/providers/hashicorp/azurerm/3.40.0/docs/resources/role_assignment) | resource |
 | [azurerm_storage_container.idpay_logo_container](https://registry.terraform.io/providers/hashicorp/azurerm/3.40.0/docs/resources/storage_container) | resource |

--- a/src/domains/idpay-app/env/prod/terraform.tfvars
+++ b/src/domains/idpay-app/env/prod/terraform.tfvars
@@ -95,7 +95,7 @@ storage_account_replication_type      = "RAGZRS"
 storage_delete_retention_days         = 90
 storage_enable_versioning             = true
 storage_advanced_threat_protection    = true
-storage_public_network_access_enabled = true
+storage_public_network_access_enabled = false
 
 #
 # RTD reverse proxy


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

Setting private access to storage for PROD environment (DEV and UAT was already private)

-target=module.idpay_audit_storage -target=module.idpay_initiative_storage -target=module.idpay_refund_storage

<!--- Describe your changes in detail -->

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

#### Has This Been Tested?

- [ ] Yes
- [ ] No

### Other information
Target: 
```

```

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] Unit Test Suite
- [ ] Integration Test Suite
- [ ] Api Tests
- [ ] Load Tests

<!-- Provide screenshot or link to test results-->
[Link to test results](https://pagopa.atlassian.net/browse/RTD-XXXX)

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
