### PR TITLE
fix: [RTD-2212] remove deprecated code of core's eventhub

### DIFF
--- a/src/domains/idpay-common/01_keyvault_external_secrets.tf
+++ b/src/domains/idpay-common/01_keyvault_external_secrets.tf
@@ -20,19 +20,6 @@ data "azurerm_key_vault_secret" "rtd_external_secrets" {
   key_vault_id = data.azurerm_key_vault.rtd_key_vault.id
 }
 
-# propagate secrets on idpay to allow connection from a different domain
-
-resource "azurerm_key_vault_secret" "event_hub_keys_on_idpay_kv" {
-  for_each = data.terraform_remote_state.core.outputs.event_hub_keys_ids
-
-  name         = format("evh-%s-%s", replace(each.key, ".", "-"), "key")
-  value        = data.terraform_remote_state.core.outputs.event_hub_keys[each.key].primary_key
-  content_type = "text/plain"
-
-  key_vault_id = module.key_vault_idpay.id
-}
-
-
 resource "azurerm_key_vault_secret" "rtd_external_secrets_on_idpay_kv" {
   count = length(data.azurerm_key_vault_secret.rtd_external_secrets)
 


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
This PR proposes to delete the deprecated code related to the core's eventhub.

### List of changes

<!--- Describe your changes in detail -->

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new resources
- [ ] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

#### Has This Been Tested?

- [ ] Yes
- [ ] No

### Other information
Target: 
```

```

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] Unit Test Suite
- [ ] Integration Test Suite
- [ ] Api Tests
- [ ] Load Tests

<!-- Provide screenshot or link to test results-->
[Link to test results](https://pagopa.atlassian.net/browse/RTD-XXXX)

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
