### PR TITLE
fix: [RTD-2306] Make invalidation pipeline idempotent

### DIFF
--- a/src/domains/tae-app/pipelines/data-explorer-activities/duplicateAndInvalidateFlow.json
+++ b/src/domains/tae-app/pipelines/data-explorer-activities/duplicateAndInvalidateFlow.json
@@ -13,7 +13,7 @@
   "userProperties": [],
   "typeProperties": {
     "command": {
-      "value": ".append Aggregates <|\nAggregates\n| where fileName == \"@{pipeline().parameters.file}\"\n| extend valid = false",
+      "value": ".append Aggregates <|\nAggregates\n| where fileName == \"@{pipeline().parameters.file}\"\n| where isnull(valid)\n| extend valid = false\n| extend pipelineRun = strcat(pipelineRun,\"_\", \"@{pipeline().RunId}\")",
       "type": "Expression"
     },
     "commandTimeout": "00:20:00"

--- a/src/domains/tae-app/pipelines/deleteAggregatesByTimestamp.json
+++ b/src/domains/tae-app/pipelines/deleteAggregatesByTimestamp.json
@@ -27,7 +27,7 @@
         "typeProperties": {
           "variableName": "ts_min",
           "value": {
-            "value": "@addSeconds(pipeline().parameters.start_ing, mul(sub(div(ticks(pipeline().parameters.schedule_time),10000000), div(ticks(pipeline().parameters.start_cleaning),10000000)), pipeline().parameters.coeff))",
+            "value": "@addSeconds(pipeline().parameters.start_ing, mul(sub(div(ticks(pipeline().parameters.schedule_time),10000000), div(ticks(pipeline().parameters.start_cleaning),10000000)), int(pipeline().parameters.coeff)))",
             "type": "Expression"
           }
         }


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
This PR proposes to make invalidate flow pipeline idempotent.
### List of changes
- add a check whether a flow is already invalid
- add invalidation pipeline run id after ingestion pipeline run id to keep track of both
- add a cast to int on a pipeline parameter.
<!--- Describe your changes in detail -->

### Motivation and context

With this changes we avoid duplicating invalid flows if more than one invalidate flow pipeline is run with the same target flow.
<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

#### Has This Been Tested?

- [x] Yes
- [ ] No

### Other information
Target: 
```
-target=azurerm_data_factory_pipeline.invalidate_flow
-target=azurerm_data_factory_pipeline.delete_aggregates_by_timestamp_pipeline
```

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] Unit Test Suite
- [x] Integration Test Suite
- [ ] Api Tests
- [ ] Load Tests

<!-- Provide screenshot or link to test results-->
As shown in the following image a second run of invalidation cannot retrieve any row to invalidate:
![image](https://github.com/pagopa/cstar-infrastructure/assets/12004943/d254c756-2c0d-4edc-bfa2-e392edc96632)

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
