### PR TITLE
fix: read pgp public key from rtd key vault

### DIFF
--- a/src/domains/rtd-app/00_key_vault.tf
+++ b/src/domains/rtd-app/00_key_vault.tf
@@ -32,5 +32,5 @@ data "azurerm_key_vault_secret" "rtd_pm_client-certificate-thumbprint" {
 data "azurerm_key_vault_secret" "cstarblobstorage_public_key" {
   count        = var.enable.csv_transaction_apis ? 1 : 0
   name         = "cstarblobstorage-public-key"
-  key_vault_id = data.azurerm_key_vault.key_vault.id
+  key_vault_id = data.azurerm_key_vault.kv.id
 }


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
This PR proposes to change the source for cstarblobstorage-public-key from the core key vault (cstar-d-kv) to rtd domain key vault (cstar-d-rtd-kv) since it's only used by RTD and the private key is already on the destination keyvault.
The public key has been migrated from core kv to rtd kv.
### List of changes

<!--- Describe your changes in detail -->

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [x] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

#### Has This Been Tested?

- [x] Yes
- [ ] No
batch service acceptance test
### Other information
Target: 
```
-target=module.rtd_csv_transaction
```

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] Unit Test Suite
- [ ] Integration Test Suite
- [ ] Api Tests
- [ ] Load Tests

<!-- Provide screenshot or link to test results-->
[Link to test results](https://pagopa.atlassian.net/browse/RTD-XXXX)

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
