### PR TITLE
fix: [RTD-2360] remove reference to old k8s snet

### DIFF
--- a/src/domains/rtd-common/00_network.tf
+++ b/src/domains/rtd-common/00_network.tf
@@ -3,12 +3,6 @@ data "azurerm_virtual_network" "vnet_core" {
   resource_group_name = local.vnet_core_resource_group_name
 }
 
-data "azurerm_subnet" "aks_old_subnet" {
-  name                 = "${var.prefix}-${var.env_short}-k8s-snet"
-  resource_group_name  = local.vnet_core_resource_group_name
-  virtual_network_name = local.vnet_core_name
-}
-
 data "azurerm_subnet" "private_endpoint_snet" {
   name                 = "private-endpoint-snet"
   virtual_network_name = local.vnet_core_name

--- a/src/domains/rtd-common/03_database.tf
+++ b/src/domains/rtd-common/03_database.tf
@@ -26,7 +26,6 @@ module "cosmosdb_account_mongodb" {
   enable_provisioned_throughput_exceeded_alert = false
 
   allowed_virtual_network_subnet_ids = [
-    data.azurerm_subnet.aks_old_subnet.id,
     data.azurerm_subnet.adf_snet.id
   ]
 

--- a/src/domains/rtd-common/04_eventhub.tf
+++ b/src/domains/rtd-common/04_eventhub.tf
@@ -25,9 +25,6 @@ resource "azurerm_eventhub_namespace" "event_hub_rtd_namespace" {
       subnet_id = data.azurerm_subnet.aks_domain_subnet.id
     }
     virtual_network_rule {
-      subnet_id = data.azurerm_subnet.aks_old_subnet.id
-    }
-    virtual_network_rule {
       subnet_id = data.azurerm_subnet.private_endpoint_snet.id
     }
     trusted_service_access_enabled = true

--- a/src/domains/rtd-common/README.md
+++ b/src/domains/rtd-common/README.md
@@ -70,7 +70,6 @@
 | [azurerm_storage_account.blobstorage_account](https://registry.terraform.io/providers/hashicorp/azurerm/3.38.0/docs/data-sources/storage_account) | data source |
 | [azurerm_subnet.adf_snet](https://registry.terraform.io/providers/hashicorp/azurerm/3.38.0/docs/data-sources/subnet) | data source |
 | [azurerm_subnet.aks_domain_subnet](https://registry.terraform.io/providers/hashicorp/azurerm/3.38.0/docs/data-sources/subnet) | data source |
-| [azurerm_subnet.aks_old_subnet](https://registry.terraform.io/providers/hashicorp/azurerm/3.38.0/docs/data-sources/subnet) | data source |
 | [azurerm_subnet.eventhub_snet](https://registry.terraform.io/providers/hashicorp/azurerm/3.38.0/docs/data-sources/subnet) | data source |
 | [azurerm_subnet.private_endpoint_snet](https://registry.terraform.io/providers/hashicorp/azurerm/3.38.0/docs/data-sources/subnet) | data source |
 | [azurerm_subscription.current](https://registry.terraform.io/providers/hashicorp/azurerm/3.38.0/docs/data-sources/subscription) | data source |


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
This PR proposes to remove the references to old k8s snet in the rtd-common domain. Those references break the terraform plan since the resource does not exist anymore
### List of changes

<!--- Describe your changes in detail -->

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

#### Has This Been Tested?

- [ ] Yes
- [x] No

### Other information
Target: 
```

```

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] Unit Test Suite
- [ ] Integration Test Suite
- [ ] Api Tests
- [ ] Load Tests

<!-- Provide screenshot or link to test results-->
[Link to test results](https://pagopa.atlassian.net/browse/RTD-XXXX)

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
