### PR TITLE
feat: [RTD-2353] Extend Log Analytics Workspace default retention

### DIFF
--- a/src/core/env/dev/terraform.tfvars
+++ b/src/core/env/dev/terraform.tfvars
@@ -279,3 +279,5 @@ sftp_ade_ack_archive_policy = {
 
 dns_forwarder_vmss_cidr = "10.1.199.16/29"
 dns_forwarder_lb_cidr   = "10.1.199.8/29"
+
+law_retention_in_days = 30

--- a/src/core/env/prod/terraform.tfvars
+++ b/src/core/env/prod/terraform.tfvars
@@ -272,3 +272,5 @@ sftp_ade_ack_archive_policy = {
 
 dns_forwarder_vmss_cidr = "10.1.199.16/29"
 dns_forwarder_lb_cidr   = "10.1.199.8/29"
+
+law_retention_in_days = 90

--- a/src/core/env/uat/terraform.tfvars
+++ b/src/core/env/uat/terraform.tfvars
@@ -276,3 +276,5 @@ sftp_ade_ack_archive_policy = {
 
 dns_forwarder_vmss_cidr = "10.1.199.16/29"
 dns_forwarder_lb_cidr   = "10.1.199.8/29"
+
+law_retention_in_days = 30


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
This PR proposes to extend the default retention of Log Analytics Workspace tables in production.
### List of changes
- differentiate log retention variable for environment.
<!--- Describe your changes in detail -->

### Motivation and context
With this change we can recover and analyze production logs up to 90 days old.
<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

#### Has This Been Tested?

- [x] Yes
- [ ] No

### Other information
Target: 
```
-target=azurerm_log_analytics_workspace.log_analytics_workspace
```

#### How Has This Been Tested?


<!-- Provide screenshot or link to test results-->
![image](https://github.com/pagopa/cstar-infrastructure/assets/12004943/73de4ca2-531c-4c7e-b1a0-e0443e090efe)

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
