### PR TITLE
fix: [RTD-2411] Alarms to opsgenie

### DIFF
--- a/src/domains/tae-app/00_monitor.tf
+++ b/src/domains/tae-app/00_monitor.tf
@@ -110,7 +110,7 @@ resource "azurerm_monitor_scheduled_query_rules_alert_v2" "sender_doesnt_send" {
   evaluation_frequency = "P1D"
   window_duration      = "P2D"
   scopes               = [data.azurerm_log_analytics_workspace.log_analytics.id]
-  severity             = 4
+  severity             = 1
   criteria {
     query                   = <<-QUERY
       let today = StorageBlobLogs
@@ -181,7 +181,7 @@ resource "azurerm_monitor_scheduled_query_rules_alert_v2" "sender_auth_failed_au
   evaluation_frequency = "PT5M"
   window_duration      = "PT5M"
   scopes               = [data.azurerm_log_analytics_workspace.log_analytics.id]
-  severity             = 4
+  severity             = 1
   criteria {
     query                   = <<-QUERY
       AppRequests
@@ -235,7 +235,7 @@ resource "azurerm_monitor_scheduled_query_rules_alert_v2" "sender_auth_missing_i
   evaluation_frequency = "PT5M"
   window_duration      = "PT5M"
   scopes               = [data.azurerm_log_analytics_workspace.log_analytics.id]
-  severity             = 4
+  severity             = 1
   criteria {
     query                   = <<-QUERY
       AppRequests
@@ -289,7 +289,7 @@ resource "azurerm_monitor_scheduled_query_rules_alert_v2" "created_file_in_ade_e
   evaluation_frequency = "PT5M"
   window_duration      = "PT5M"
   scopes               = [data.azurerm_log_analytics_workspace.log_analytics.id]
-  severity             = 4
+  severity             = 2
   criteria {
     query                   = <<-QUERY
       let created = StorageBlobLogs
@@ -350,7 +350,7 @@ resource "azurerm_monitor_scheduled_query_rules_alert_v2" "sender_fails_blob_upl
   evaluation_frequency = "PT5M"
   window_duration      = "PT5M"
   scopes               = [data.azurerm_log_analytics_workspace.log_analytics.id]
-  severity             = 4
+  severity             = 1
   criteria {
     query                   = <<-QUERY
       AzureDiagnostics
@@ -409,7 +409,7 @@ resource "azurerm_monitor_scheduled_query_rules_alert_v2" "sender_fails_blob_upl
   evaluation_frequency = "PT5M"
   window_duration      = "PT5M"
   scopes               = [data.azurerm_log_analytics_workspace.log_analytics.id]
-  severity             = 4
+  severity             = 1
   criteria {
     query                   = <<-QUERY
       AppRequests
@@ -465,7 +465,7 @@ resource "azurerm_monitor_scheduled_query_rules_alert_v2" "sender_fails_blob_upl
   evaluation_frequency = "PT5M"
   window_duration      = "PT5M"
   scopes               = [data.azurerm_log_analytics_workspace.log_analytics.id]
-  severity             = 4
+  severity             = 1
   criteria {
     query                   = <<-QUERY
       AppRequests
@@ -521,7 +521,7 @@ resource "azurerm_monitor_scheduled_query_rules_alert_v2" "ade_removes_ack_file"
   evaluation_frequency = "PT5M"
   window_duration      = "PT5M"
   scopes               = [data.azurerm_log_analytics_workspace.log_analytics.id]
-  severity             = 4
+  severity             = 1
   criteria {
     query                   = <<-QUERY
       StorageBlobLogs
@@ -574,7 +574,7 @@ resource "azurerm_monitor_scheduled_query_rules_alert_v2" "not_all_chunks_are_ve
   evaluation_frequency = "PT5M"
   window_duration      = "PT5M"
   scopes               = [data.azurerm_log_analytics_workspace.log_analytics.id]
-  severity             = 3
+  severity             = 2
   criteria {
     query                   = <<-QUERY
       AppTraces
@@ -626,7 +626,7 @@ resource "azurerm_monitor_scheduled_query_rules_alert_v2" "failed_decryption" {
   evaluation_frequency = "PT5M"
   window_duration      = "PT5M"
   scopes               = [data.azurerm_log_analytics_workspace.log_analytics.id]
-  severity             = 3
+  severity             = 2
   criteria {
     query                   = <<-QUERY
       AppTraces
@@ -678,7 +678,7 @@ resource "azurerm_monitor_scheduled_query_rules_alert_v2" "no_data_in_decryted_f
   evaluation_frequency = "PT5M"
   window_duration      = "PT5M"
   scopes               = [data.azurerm_log_analytics_workspace.log_analytics.id]
-  severity             = 3
+  severity             = 2
   criteria {
     query                   = <<-QUERY
       AppTraces
@@ -730,7 +730,7 @@ resource "azurerm_monitor_scheduled_query_rules_alert_v2" "wrong_name_format" {
   evaluation_frequency = "PT5M"
   window_duration      = "PT5M"
   scopes               = [data.azurerm_log_analytics_workspace.log_analytics.id]
-  severity             = 4
+  severity             = 1
   criteria {
     query                   = <<-QUERY
       AppTraces
@@ -782,7 +782,7 @@ resource "azurerm_monitor_scheduled_query_rules_alert_v2" "ack_ingestor_failures
   evaluation_frequency = "PT5M"
   window_duration      = "PT5M"
   scopes               = [data.azurerm_log_analytics_workspace.log_analytics.id]
-  severity             = 3
+  severity             = 2
   criteria {
     query                   = <<-QUERY
       AzureDiagnostics
@@ -835,7 +835,7 @@ resource "azurerm_monitor_scheduled_query_rules_alert_v2" "aggregates_ingestor_f
   evaluation_frequency = "PT5M"
   window_duration      = "PT5M"
   scopes               = [data.azurerm_log_analytics_workspace.log_analytics.id]
-  severity             = 3
+  severity             = 1
   criteria {
     query                   = <<-QUERY
       AzureDiagnostics
@@ -889,7 +889,7 @@ resource "azurerm_monitor_scheduled_query_rules_alert_v2" "file_not_created_in_a
   evaluation_frequency = "P1D"
   window_duration      = "P1D"
   scopes               = [data.azurerm_log_analytics_workspace.log_analytics.id]
-  severity             = 4
+  severity             = 2
   criteria {
     query                   = <<-QUERY
       let blobsPastDaysIn = StorageBlobLogs
@@ -954,7 +954,7 @@ resource "azurerm_monitor_scheduled_query_rules_alert_v2" "failure_on_sas_token_
   evaluation_frequency = "PT5M"
   window_duration      = "PT5M"
   scopes               = [data.azurerm_log_analytics_workspace.log_analytics.id]
-  severity             = 4
+  severity             = 1
   criteria {
     query                   = <<-QUERY
       AzureDiagnostics
@@ -1007,7 +1007,7 @@ resource "azurerm_monitor_scheduled_query_rules_alert_v2" "file_already_present_
   evaluation_frequency = "PT5M"
   window_duration      = "PT5M"
   scopes               = [data.azurerm_log_analytics_workspace.log_analytics.id]
-  severity             = 4
+  severity             = 1
   criteria {
     query                   = <<-QUERY
       AppTraces
@@ -1059,7 +1059,7 @@ resource "azurerm_monitor_scheduled_query_rules_alert_v2" "failure_on_sender_ade
   evaluation_frequency = "PT5M"
   window_duration      = "PT5M"
   scopes               = [data.azurerm_log_analytics_workspace.log_analytics.id]
-  severity             = 4
+  severity             = 1
   criteria {
     query                   = <<-QUERY
       AzureDiagnostics
@@ -1116,7 +1116,7 @@ resource "azurerm_monitor_scheduled_query_rules_alert_v2" "pgp_file_already_pres
   evaluation_frequency = "PT5M"
   window_duration      = "PT5M"
   scopes               = [data.azurerm_log_analytics_workspace.log_analytics.id]
-  severity             = 4
+  severity             = 1
   criteria {
     query                   = <<-QUERY
       AzureDiagnostics
@@ -1174,7 +1174,7 @@ resource "azurerm_monitor_scheduled_query_rules_alert_v2" "upload_pgp_with_no_co
   evaluation_frequency = "PT5M"
   window_duration      = "PT5M"
   scopes               = [data.azurerm_log_analytics_workspace.log_analytics.id]
-  severity             = 4
+  severity             = 1
   criteria {
     query                   = <<-QUERY
       AzureDiagnostics
@@ -1232,7 +1232,7 @@ resource "azurerm_monitor_scheduled_query_rules_alert_v2" "upload_pgp_with_conte
   evaluation_frequency = "PT5M"
   window_duration      = "PT5M"
   scopes               = [data.azurerm_log_analytics_workspace.log_analytics.id]
-  severity             = 4
+  severity             = 1
   criteria {
     query                   = <<-QUERY
       AzureDiagnostics
@@ -1290,7 +1290,7 @@ resource "azurerm_monitor_scheduled_query_rules_alert_v2" "deprecated_batch_serv
   evaluation_frequency = "P1D"
   window_duration      = "P1D"
   scopes               = [data.azurerm_log_analytics_workspace.log_analytics.id]
-  severity             = 4
+  severity             = 1
   criteria {
     query                   = <<-QUERY
       AzureDiagnostics
@@ -1338,7 +1338,7 @@ resource "azurerm_monitor_scheduled_query_rules_alert_v2" "client-certificate-cl
   evaluation_frequency = "P1D"
   window_duration      = "P2D"
   scopes               = [data.azurerm_log_analytics_workspace.log_analytics.id]
-  severity             = 4
+  severity             = 3
   criteria {
     query                   = <<-QUERY
       AppRequests

--- a/src/domains/tae-app/01_monitor_incident.tf
+++ b/src/domains/tae-app/01_monitor_incident.tf
@@ -1,17 +1,4 @@
-resource "azurerm_monitor_action_group" "send_to_opsgenie" {
 
-  count = var.env_short == "p" ? 1 : 0
-
-  name                = "send_to_opsgenie"
-  resource_group_name = data.azurerm_resource_group.monitor_rg.name
-  short_name          = "send_to_gen"
-
-  webhook_receiver {
-    name                    = "send_to_opsgenie"
-    service_uri             = data.azurerm_key_vault_secret.opsgenie_webhook_url[count.index].value
-    use_common_alert_schema = true
-  }
-}
 
 resource "azurerm_monitor_scheduled_query_rules_alert_v2" "cstar-ade-in-missing-files" {
 


### PR DESCRIPTION

This PR sets alarm severity base on the following criteria : 
- Severity 4 -> alarm will be managed by Operation Team. 
- Severity 3+ -> alarm will be managed by IRT 

Moreover 
All alarms will be delivered to OpsGenie. OpsGenie will be our alarm control rooms.
action group related to ZenDesk has been removed from alarms ( but it's still available as resource)
Action group related to Slack is still available in order to monitor OpsGenie integration.


### List of changes

resource opsgenie has been moved, but it's not changed
Change action grouops and severity to alarms

<!--- Describe your changes in detail -->

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new resources
- [X] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [X] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

#### Has This Been Tested?

- [ ] Yes
- [X] No

### Other information
Target: 
```

```

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] Unit Test Suite
- [ ] Integration Test Suite
- [ ] Api Tests
- [ ] Load Tests

<!-- Provide screenshot or link to test results-->
[Link to test results](https://pagopa.atlassian.net/browse/RTD-XXXX)

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
