### PR TITLE
fix: [RTD-2473] add apim internal host to config map reporter

### DIFF
--- a/src/domains/rtd-app/08_k8s_configmaps.tf
+++ b/src/domains/rtd-app/08_k8s_configmaps.tf
@@ -245,7 +245,7 @@ resource "kubernetes_config_map" "rtdfilereporter" {
   data = merge({
     JAVA_TOOL_OPTIONS             = "-javaagent:/app/applicationinsights-agent.jar"
     APPLICATIONINSIGHTS_ROLE_NAME = "rtdfilereporter"
-    STORAGE_ACCOUNT_HOST = replace("apim.internal.${var.env}.cstar.pagopa.it", ".prod.", ".")
+    STORAGE_ACCOUNT_HOST          = replace("apim.internal.${var.env}.cstar.pagopa.it", ".prod.", ".")
   }, var.configmaps_rtdfilereporter)
 }
 

--- a/src/domains/rtd-app/08_k8s_configmaps.tf
+++ b/src/domains/rtd-app/08_k8s_configmaps.tf
@@ -245,6 +245,7 @@ resource "kubernetes_config_map" "rtdfilereporter" {
   data = merge({
     JAVA_TOOL_OPTIONS             = "-javaagent:/app/applicationinsights-agent.jar"
     APPLICATIONINSIGHTS_ROLE_NAME = "rtdfilereporter"
+    STORAGE_ACCOUNT_HOST = replace("apim.internal.${var.env}.cstar.pagopa.it", ".prod.", ".")
   }, var.configmaps_rtdfilereporter)
 }
 


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
This PR proposes to add a variable to the rtd-ms-file-reporter config map. The variable is needed to connect to the internal url of APIM
### List of changes

<!--- Describe your changes in detail -->

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

#### Has This Been Tested?

- [ ] Yes
- [ ] No

### Other information
Target: 
```
-target=kubernetes_config_map.rtdfilereporter 
```

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] Unit Test Suite
- [ ] Integration Test Suite
- [ ] Api Tests
- [ ] Load Tests

<!-- Provide screenshot or link to test results-->
[Link to test results](https://pagopa.atlassian.net/browse/RTD-XXXX)

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
