### PR TITLE
feat: [TAE-215] Add alert when a GET of a pgp on decrypter fails

### DIFF
--- a/src/domains/tae-app/00_monitor.tf
+++ b/src/domains/tae-app/00_monitor.tf
@@ -1386,11 +1386,18 @@ resource "azurerm_monitor_scheduled_query_rules_alert_v2" "file-not-processed-by
           and Message startswith "Wrong name format:"
       | extend CommonFilename = tostring(split(Message, '/', 6)[0])
       | project CommonFilename = replace_string(replace_string(CommonFilename, "TRNLOG.", ""), ".csv.pgp", "");
+      let failedGet = AppTraces
+      | where AppRoleName == "rtddecrypter"
+        and SeverityLevel == 3
+        and Message startswith "Cannot GET blob "
+      | extend Filename = tostring(extract(@"Cannot GET blob (.*)", 1, MyMessage))
+      | project CommonFilename = replace_string(replace_string(Filename, "TRNLOG.", ""), ".csv.pgp", "");
       let decryptedAndFailures = decrypted
           | union cannotDecrypt
               | union noDataFound
                   | union notVerified
-                      | union wrongNameFormat;
+                      | union wrongNameFormat
+                        | union failedGet;
       encrypted
           | join kind = leftanti decryptedAndFailures on CommonFilename
       QUERY
@@ -1593,4 +1600,56 @@ resource "azurerm_monitor_scheduled_query_rules_alert_v2" "at-least-one-pending-
     }
   }
 
+}
+
+resource "azurerm_monitor_scheduled_query_rules_alert_v2" "cannot_get_encrypted_file" {
+
+  count = var.env_short == "p" ? 1 : 0
+
+  name                = "cstar-${var.env_short}-decrypter-cannot-get-encrypted-file"
+  resource_group_name = data.azurerm_resource_group.monitor_rg.name
+  location            = data.azurerm_resource_group.monitor_rg.location
+
+  evaluation_frequency = "PT5M"
+  window_duration      = "PT5M"
+  scopes               = [data.azurerm_log_analytics_workspace.log_analytics.id]
+  severity             = 1
+  criteria {
+    query                   = <<-QUERY
+      AppTraces
+      | where AppRoleName == "rtddecrypter"
+      | where SeverityLevel == 3
+      | where Message startswith "Cannot GET blob "
+      QUERY
+    time_aggregation_method = "Count"
+    threshold               = 0
+    operator                = "GreaterThan"
+
+    failing_periods {
+      minimum_failing_periods_to_trigger_alert = 1
+      number_of_evaluation_periods             = 1
+    }
+  }
+
+  auto_mitigation_enabled          = false
+  workspace_alerts_storage_enabled = false
+  description                      = "Triggers whenever at least one blob cannot be obtained by decrypter."
+  display_name                     = "cstar-${var.env_short}-decrypter-cannot-get-encrypted-file-#ACQ"
+  enabled                          = true
+
+  skip_query_validation = false
+  action {
+    action_groups = [
+      azurerm_monitor_action_group.send_to_operations[0].id,
+      azurerm_monitor_action_group.send_to_opsgenie[count.index].id, # Opsgenie
+    ]
+    custom_properties = {
+      key  = "value"
+      key2 = "value2"
+    }
+  }
+
+  tags = {
+    key = "Sender Monitoring"
+  }
 }

--- a/src/domains/tae-app/00_monitor.tf
+++ b/src/domains/tae-app/00_monitor.tf
@@ -1390,7 +1390,7 @@ resource "azurerm_monitor_scheduled_query_rules_alert_v2" "file-not-processed-by
       | where AppRoleName == "rtddecrypter"
         and SeverityLevel == 3
         and Message startswith "Cannot GET blob "
-      | extend Filename = tostring(extract(@"Cannot GET blob (.*)", 1, MyMessage))
+      | extend Filename = tostring(extract(@"Cannot GET blob (.*)", 1, Message))
       | project CommonFilename = replace_string(replace_string(Filename, "TRNLOG.", ""), ".csv.pgp", "");
       let decryptedAndFailures = decrypted
           | union cannotDecrypt

--- a/src/domains/tae-app/README.md
+++ b/src/domains/tae-app/README.md
@@ -56,6 +56,7 @@ No modules.
 | [azurerm_monitor_scheduled_query_rules_alert_v2.ade_removes_ack_file](https://registry.terraform.io/providers/hashicorp/azurerm/3.40.0/docs/resources/monitor_scheduled_query_rules_alert_v2) | resource |
 | [azurerm_monitor_scheduled_query_rules_alert_v2.aggregates_ingestor_failures](https://registry.terraform.io/providers/hashicorp/azurerm/3.40.0/docs/resources/monitor_scheduled_query_rules_alert_v2) | resource |
 | [azurerm_monitor_scheduled_query_rules_alert_v2.at-least-one-pending-file-in-Cosmos](https://registry.terraform.io/providers/hashicorp/azurerm/3.40.0/docs/resources/monitor_scheduled_query_rules_alert_v2) | resource |
+| [azurerm_monitor_scheduled_query_rules_alert_v2.cannot_get_encrypted_file](https://registry.terraform.io/providers/hashicorp/azurerm/3.40.0/docs/resources/monitor_scheduled_query_rules_alert_v2) | resource |
 | [azurerm_monitor_scheduled_query_rules_alert_v2.client-certificate-close-to-expiry-date](https://registry.terraform.io/providers/hashicorp/azurerm/3.40.0/docs/resources/monitor_scheduled_query_rules_alert_v2) | resource |
 | [azurerm_monitor_scheduled_query_rules_alert_v2.created_file_in_ade_error](https://registry.terraform.io/providers/hashicorp/azurerm/3.40.0/docs/resources/monitor_scheduled_query_rules_alert_v2) | resource |
 | [azurerm_monitor_scheduled_query_rules_alert_v2.cstar-ade-in-missing-files](https://registry.terraform.io/providers/hashicorp/azurerm/3.40.0/docs/resources/monitor_scheduled_query_rules_alert_v2) | resource |


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
This PR proposes to add an alert that triggers whenever the decrypter can't get a file from storage account.
This also changes the "catch-all" alert.
### List of changes

<!--- Describe your changes in detail -->

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new resources
- [ ] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

#### Has This Been Tested?

- [ ] Yes
- [ ] No

### Other information
Target: 
```
-target=azurerm_monitor_scheduled_query_rules_alert_v2.cannot_get_encrypted_file -target=azurerm_monitor_scheduled_query_rules_alert_v2.file-not-processed-by-decrypter
```

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] Unit Test Suite
- [ ] Integration Test Suite
- [ ] Api Tests
- [ ] Load Tests

<!-- Provide screenshot or link to test results-->
[Link to test results](https://pagopa.atlassian.net/browse/RTD-XXXX)

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
