### PR TITLE
fix: [TAE-300] Fix name cleaning in file not validated

### DIFF
--- a/src/domains/tae-app/00_monitor.tf
+++ b/src/domains/tae-app/00_monitor.tf
@@ -1378,7 +1378,7 @@ resource "azurerm_monitor_scheduled_query_rules_alert_v2" "file-not-processed-by
           and SeverityLevel == 3
           and Message startswith "Not all chunks are verified, no chunks will be uploaded"
       | project Filename = tostring(extract(@"Not all chunks are verified, no chunks will be uploaded of (.*)", 1, Message))
-      | project CommonFilename = replace_string(replace_string(Filename, "TRNLOG.", ""), ".csv.pgp", "");
+      | project CommonFilename = replace_string(replace_string(replace_string(Filename, "ADE.", ""), "TRNLOG.", ""), ".csv.pgp", "");
       let wrongNameFormat = AppTraces
       | where TimeGenerated >= evaluation_start_time
           and AppRoleName == "rtddecrypter"


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
This PR proposes to fix an intermediate query to match file naming convention.
### List of changes
- modify intermediate query
<!--- Describe your changes in detail -->

### Motivation and context
With this change we can be notified only by the original alert and not by the "catch-all" one.
<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

#### Has This Been Tested?

- [ ] Yes
- [x] No

### Other information
Target: 
```
-target=azurerm_monitor_scheduled_query_rules_alert_v2.file-not-processed-by-decrypter
```

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] Unit Test Suite
- [ ] Integration Test Suite
- [ ] Api Tests
- [ ] Load Tests

<!-- Provide screenshot or link to test results-->
[Link to test results](https://pagopa.atlassian.net/browse/RTD-XXXX)

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
