### PR TITLE
feat: [PAYMCLOUD-303] Add OpsGenie webhook integration for infrastructure alerts

### DIFF
--- a/src/core-secrets/secret/prod/noedit_secret_enc.json
+++ b/src/core-secrets/secret/prod/noedit_secret_enc.json
@@ -1,4 +1,5 @@
 {
+	"opsgenie-cstar-infra-webhook-token": "ENC[AES256_GCM,data:uL4M8EGXB838kjBEgURh2aB3MHpfqJMqKUCD15ZryB0CZj4c,iv:uamrNtadF+OnZkOl/2oQE+sMOUjHwSGs7cufX91Dsb0=,tag:CwaQuh8imtRbN9bLbVCUIg==,type:str]",
 	"sops": {
 		"kms": null,
 		"gcp_kms": null,
@@ -13,8 +14,8 @@
 		],
 		"hc_vault": null,
 		"age": null,
-		"lastmodified": "2025-03-06T11:27:16Z",
-		"mac": "ENC[AES256_GCM,data:tJUf1CfbuJ1zV319p7Hi4igsaQw+p3qPpbsACqbhKEY9ljC1bs9w/GNkYl+Pm2/rByi2SZbuxCR+rtxf2KVMR+BVHBZNTKEzjrA0nJJ1gbxyEGc9m9R/WrKU1ZlKHrV/3b/PyfsUYqOfKivS+Tidq0CtZAleRhMmJWOydbml7JQ=,iv:uV/GTfWzuxXCw0XfwjYC9M8n7FzPl5E1InTvpAdCZ+o=,tag:z7OmyolPrKgm/XnndWtCcQ==,type:str]",
+		"lastmodified": "2025-03-06T15:37:58Z",
+		"mac": "ENC[AES256_GCM,data:h4bw+tfKr3yAqr5huGQCJXq3DxOHz0ySiwqQOroFC6rlmIbwhWpmPIgoum0C1yjyX8IjodhmklcfTR3k/JE7GfmKFVFIz1inDhRJjgzvKZJO7k7S67pRxXhTMvJlk9BkU4bP7N8eWeYpEZ06pHW+3z13hfaDEndupFsve2/sS7o=,iv:olEuh8DbOUzUhNFi7opImzOJ1tU+6sIOARByY0wWZ6Y=,tag:GjBr/48ZNOdA7V8yzWsYYg==,type:str]",
 		"pgp": null,
 		"unencrypted_suffix": "_unencrypted",
 		"version": "3.9.4"

--- a/src/core/README.md
+++ b/src/core/README.md
@@ -134,6 +134,7 @@
 | [azurerm_log_analytics_workspace.log_analytics_workspace](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/log_analytics_workspace) | resource |
 | [azurerm_monitor_action_group.core](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_action_group) | resource |
 | [azurerm_monitor_action_group.core_send_to_opsgenie](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_action_group) | resource |
+| [azurerm_monitor_action_group.cstar_infra_opsgenie](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_action_group) | resource |
 | [azurerm_monitor_action_group.email](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_action_group) | resource |
 | [azurerm_monitor_action_group.error](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_action_group) | resource |
 | [azurerm_monitor_action_group.slack](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_action_group) | resource |
@@ -279,6 +280,7 @@
 | [azurerm_key_vault_secret.cruscotto-basic-auth-pwd](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/key_vault_secret) | data source |
 | [azurerm_key_vault_secret.monitor_notification_email](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/key_vault_secret) | data source |
 | [azurerm_key_vault_secret.monitor_notification_slack_email](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/key_vault_secret) | data source |
+| [azurerm_key_vault_secret.opsgenie_cstar_infra_webhook_key](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/key_vault_secret) | data source |
 | [azurerm_key_vault_secret.opsgenie_webhook_url](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/key_vault_secret) | data source |
 | [azurerm_key_vault_secret.pagopa_platform_api_tkm_key](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/key_vault_secret) | data source |
 | [azurerm_key_vault_secret.pm_np_wallet_basic_auth](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/key_vault_secret) | data source |

--- a/src/core/key_vault_0.tf
+++ b/src/core/key_vault_0.tf
@@ -212,7 +212,7 @@ data "azurerm_key_vault" "rtd_domain_kv" {
 # INFRA OpsGenie Cstar_Azure_infra_prod webhook key
 data "azurerm_key_vault_secret" "opsgenie_cstar_infra_webhook_key" {
   count = var.env_short == "p" ? 1 : 0
-  name  = "opsgenie-infra-webhook-token"
+  name  = "opsgenie-cstar-infra-webhook-token"
 
   key_vault_id = module.key_vault.id
 }

--- a/src/core/key_vault_0.tf
+++ b/src/core/key_vault_0.tf
@@ -208,3 +208,11 @@ data "azurerm_key_vault" "rtd_domain_kv" {
   name                = local.rtd_keyvault_name
   resource_group_name = local.rtd_rg_keyvault_name
 }
+
+# INFRA OpsGenie Cstar_Azure_infra_prod webhook key
+data "azurerm_key_vault_secret" "opsgenie_cstar_infra_webhook_key" {
+  count = var.env_short == "p" ? 1 : 0
+  name  = "opsgenie-infra-webhook-token"
+
+  key_vault_id = module.key_vault.id
+}

--- a/src/core/observability.tf
+++ b/src/core/observability.tf
@@ -130,6 +130,21 @@ resource "azurerm_monitor_action_group" "core_send_to_opsgenie" {
   }
 }
 
+resource "azurerm_monitor_action_group" "cstar_infra_opsgenie" { #
+  count               = var.env_short == "p" ? 1 : 0
+  name                = "CstarInfraOpsgenie"
+  resource_group_name = azurerm_resource_group.monitor_rg.name
+  short_name          = "InfrOpsgenie"
+
+  webhook_receiver {
+    name                    = "CstarINFRAOpsgenieWebhook"
+    service_uri             = "https://api.opsgenie.com/v1/json/azure?apiKey=${data.azurerm_key_vault_secret.opsgenie_cstar_infra_webhook_key[0].value}"
+    use_common_alert_schema = true
+  }
+
+  tags = var.tags
+}
+
 resource "azurerm_monitor_diagnostic_setting" "apim_diagnostic_settings" {
   count = var.env_short == "p" ? 1 : 0 # this resource should exists only in prod
 


### PR DESCRIPTION
**Description:**  

### List of changes
- Added OpsGenie action group for Azure monitoring in production.
- Configured webhook for enhanced alerting of Cstar Infra events.
- Secured webhook token management via key vault updates.

### Motivation and context
This integration improves alerting capabilities for infrastructure-related incidents, ensuring timely notifications.

### Type of changes
- [x] Add new resources  
- [ ] Update configuration to existing resources  
- [ ] Remove existing resources  

### Does this introduce a change to production resources with possible user impact?
- [x] Yes, users may be impacted applying this change  
- [ ] No  

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result
- [ ] Yes  
- [x] No  

### How Has This Been Tested?
- [x] Unit Test Suite  
- [x] Integration Test Suite  
- [x] Api Tests  
- [ ] Load Tests  

[Link to test results](https://pagopa.atlassian.net/browse/RTD-XXXX)

---