### PR TITLE
feat: [PAYMCLOUD-304] Enable OpsGenie alerts for production environment for aks-platform

### DIFF
--- a/src/aks-platform/00_monitor.tf
+++ b/src/aks-platform/00_monitor.tf
@@ -40,3 +40,9 @@ data "azurerm_monitor_action_group" "error" {
 #   name                = local.monitor_security_storage_name
 #   resource_group_name = data.azurerm_resource_group.rg_monitor.name
 # }
+
+data "azurerm_monitor_action_group" "opsgenie" {
+  count               = var.env_short == "p" ? 1 : 0
+  resource_group_name = var.monitor_resource_group_name
+  name                = local.monitor_action_group_opsgenie_name
+}

--- a/src/aks-platform/03_aks_0.tf
+++ b/src/aks-platform/03_aks_0.tf
@@ -104,16 +104,29 @@ module "aks" {
   # custom_metric_alerts  = var.aks_metric_alerts_custom
 
   alerts_enabled = var.aks_alerts_enabled
-  action = [
-    {
-      action_group_id    = data.azurerm_monitor_action_group.slack.id
-      webhook_properties = null
-    },
-    {
-      action_group_id    = data.azurerm_monitor_action_group.email.id
-      webhook_properties = null
-    }
-  ]
+
+  # takes a list and replaces any elements that are lists with a
+  # flattened sequence of the list contents.
+  # In this case, we enable OpsGenie only on prod env
+  action = flatten([
+    [
+      {
+        action_group_id    = data.azurerm_monitor_action_group.slack.id
+        webhook_properties = null
+      },
+      {
+        action_group_id    = data.azurerm_monitor_action_group.email.id
+        webhook_properties = null
+      }
+    ],
+    (var.env == "prod" ? [
+      {
+        action_group_id    = data.azurerm_monitor_action_group.opsgenie.0.id
+        webhook_properties = null
+      }
+    ] : [])
+  ])
+
   tags = var.tags
 
   depends_on = [

--- a/src/aks-platform/99_locals.tf
+++ b/src/aks-platform/99_locals.tf
@@ -25,6 +25,7 @@ locals {
   monitor_log_analytics_workspace_name = "${local.product}-law"
   monitor_appinsights_name             = "${local.product}-appinsights"
   monitor_security_storage_name        = replace("${local.product}-sec-monitor-st", "-", "")
+  monitor_action_group_opsgenie_name   = "CstarInfraOpsgenie"
 
   monitor_action_group_slack_name = "SlackPagoPA"
   monitor_action_group_email_name = "PagoPA"

--- a/src/aks-platform/99_variables.tf
+++ b/src/aks-platform/99_variables.tf
@@ -441,3 +441,8 @@ variable "reloader_helm" {
   })
   description = "reloader helm chart configuration"
 }
+
+variable "monitor_resource_group_name" {
+  type        = string
+  description = "Monitor resource group name"
+}

--- a/src/aks-platform/README.md
+++ b/src/aks-platform/README.md
@@ -88,6 +88,7 @@ Re-enable all the resource, commented before to complete the procedure
 | [azurerm_monitor_action_group.core](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/monitor_action_group) | data source |
 | [azurerm_monitor_action_group.email](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/monitor_action_group) | data source |
 | [azurerm_monitor_action_group.error](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/monitor_action_group) | data source |
+| [azurerm_monitor_action_group.opsgenie](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/monitor_action_group) | data source |
 | [azurerm_monitor_action_group.slack](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/monitor_action_group) | data source |
 | [azurerm_public_ip.pip_aks_outboud](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/public_ip) | data source |
 | [azurerm_resource_group.rg_monitor](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group) | data source |
@@ -141,6 +142,7 @@ Re-enable all the resource, commented before to complete the procedure
 | <a name="input_location_short"></a> [location\_short](#input\_location\_short) | Location short like eg: weu, neu.. | `string` | n/a | yes |
 | <a name="input_location_string"></a> [location\_string](#input\_location\_string) | One of West Europe, North Europe | `string` | n/a | yes |
 | <a name="input_lock_enable"></a> [lock\_enable](#input\_lock\_enable) | Apply locks to block accedentaly deletions. | `bool` | `false` | no |
+| <a name="input_monitor_resource_group_name"></a> [monitor\_resource\_group\_name](#input\_monitor\_resource\_group\_name) | Monitor resource group name | `string` | n/a | yes |
 | <a name="input_nginx_helm_version"></a> [nginx\_helm\_version](#input\_nginx\_helm\_version) | NGINX helm verison | `string` | n/a | yes |
 | <a name="input_prefix"></a> [prefix](#input\_prefix) | n/a | `string` | `"cstar"` | no |
 | <a name="input_public_ip_aksoutbound_name"></a> [public\_ip\_aksoutbound\_name](#input\_public\_ip\_aksoutbound\_name) | Public IP AKS outbound | `string` | n/a | yes |

--- a/src/aks-platform/env/prod01/terraform.tfvars
+++ b/src/aks-platform/env/prod01/terraform.tfvars
@@ -38,7 +38,7 @@ public_ip_aksoutbound_name = "cstar-p-weu-prod01-aksoutbound-pip-1"
 
 aks_enabled                 = true
 aks_private_cluster_enabled = true
-aks_alerts_enabled          = false
+aks_alerts_enabled          = true
 aks_kubernetes_version      = "1.29.4"
 aks_sku_tier                = "Standard"
 aks_system_node_pool = {


### PR DESCRIPTION
### List of changes

1. Added support for OpsGenie alerts specific to the production environment.
2. Introduced a variable for the monitor resource group name.
3. Added a local value for the OpsGenie action group reference.
4. Updated alert configurations to include OpsGenie handling for the production environment.
5. Enabled alerts in the "prod01" configuration.

### Motivation and context

This change integrates OpsGenie alerting for better incident management in the production environment. It ensures critical alerts are routed appropriately to improve response times and incident resolution.

### Type of changes

- [x] Add new resources
- [x] Update configuration to existing resources  

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change  

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [x] No  

#### Has This Been Tested?

- [x] Unit Test Suite  
- [x] Integration Test Suite  

### Other information

This change has been validated in the testing environment and the configurations were confirmed to work as intended