### PR TITLE
feat: [PAYMCLOUD-334] Remove vnet_core_peering_secure_hub module from network.tf

### DIFF
--- a/src/core/README.md
+++ b/src/core/README.md
@@ -61,7 +61,6 @@
 | <a name="module_storage_account_snet"></a> [storage\_account\_snet](#module\_storage\_account\_snet) | git::https://github.com/pagopa/terraform-azurerm-v3.git//subnet | v8.13.0 |
 | <a name="module_vnet"></a> [vnet](#module\_vnet) | git::https://github.com/pagopa/terraform-azurerm-v3.git//virtual_network | v8.13.0 |
 | <a name="module_vnet_aks"></a> [vnet\_aks](#module\_vnet\_aks) | git::https://github.com/pagopa/terraform-azurerm-v3.git//virtual_network | v8.13.0 |
-| <a name="module_vnet_core_peering_secure_hub"></a> [vnet\_core\_peering\_secure\_hub](#module\_vnet\_core\_peering\_secure\_hub) | git::https://github.com/pagopa/terraform-azurerm-v3.git//virtual_network_peering | v8.13.0 |
 | <a name="module_vnet_integration"></a> [vnet\_integration](#module\_vnet\_integration) | git::https://github.com/pagopa/terraform-azurerm-v3.git//virtual_network | v8.13.0 |
 | <a name="module_vnet_integration_peering_2_aks"></a> [vnet\_integration\_peering\_2\_aks](#module\_vnet\_integration\_peering\_2\_aks) | git::https://github.com/pagopa/terraform-azurerm-v3.git//virtual_network_peering | v8.13.0 |
 | <a name="module_vnet_pair"></a> [vnet\_pair](#module\_vnet\_pair) | git::https://github.com/pagopa/terraform-azurerm-v3.git//virtual_network | v8.13.0 |

--- a/src/core/network.tf
+++ b/src/core/network.tf
@@ -34,25 +34,6 @@ module "vnet_peering" {
   target_use_remote_gateways       = false # needed by vnet peering with SIA
 }
 
-module "vnet_core_peering_secure_hub" {
-  source = "git::https://github.com/pagopa/terraform-azurerm-v3.git//virtual_network_peering?ref=v8.13.0"
-
-  for_each = local.secure_hub_vnets
-
-  # Parametri relativi alla VNET sorgente (core)
-  source_resource_group_name       = azurerm_resource_group.rg_vnet.name
-  source_virtual_network_name      = module.vnet.name
-  source_remote_virtual_network_id = module.vnet.id
-  source_allow_gateway_transit     = true
-
-
-  # Parametri target prelevati dal data source per ciascuna VNET secure hub
-  target_resource_group_name       = each.value.resource_group_name
-  target_virtual_network_name      = each.value.name
-  target_remote_virtual_network_id = each.value.id
-  target_use_remote_gateways       = true
-}
-
 #
 # vnet integration/APIM
 #


### PR DESCRIPTION
### List of changes
- Removed `vnet_core_peering_secure_hub` module from `network.tf`.

### Motivation and context
The removal simplifies the codebase and reflects architectural changes. The `vnet_core_peering_secure_hub` module was deemed redundant and is no longer needed for managing secure hub VNet peering configurations.

### Type of changes
- [x] Remove existing resources

### Does this introduce a change to production resources with possible user impact?
- [x] Yes, users may be impacted applying this change

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result
- [ ] Yes
- [x] No

#### Has This Been Tested?
- [ ] Yes
- [x] No