### PR TITLE
feat: [PAYMCLOUD-311] Remove deprecated `tls_checker` module and references.

### DIFF
--- a/src/domains/idpay-app/80_middleware_tools.tf
+++ b/src/domains/idpay-app/80_middleware_tools.tf
@@ -1,25 +1,3 @@
-module "tls_checker" {
-  source = "./.terraform/modules/__v3__/tls_checker"
-
-  https_endpoint                                            = local.domain_aks_hostname
-  alert_name                                                = local.domain_aks_hostname
-  alert_enabled                                             = true
-  helm_chart_present                                        = true
-  namespace                                                 = kubernetes_namespace.domain_namespace.metadata[0].name
-  location_string                                           = var.location_string
-  kv_secret_name_for_application_insights_connection_string = "appinsights-instrumentation-key"
-  application_insights_resource_group                       = data.azurerm_resource_group.monitor_rg.name
-  application_insights_id                                   = data.azurerm_application_insights.application_insights.id
-  application_insights_action_group_ids                     = [data.azurerm_monitor_action_group.slack.id, data.azurerm_monitor_action_group.email.id]
-  keyvault_tenant_id                                        = data.azurerm_subscription.current.tenant_id
-  keyvault_name                                             = data.azurerm_key_vault.kv.name
-
-  workload_identity_enabled              = true
-  workload_identity_service_account_name = module.workload_identity.workload_identity_service_account_name
-  workload_identity_client_id            = module.workload_identity.workload_identity_client_id
-  depends_on                             = [module.workload_identity]
-}
-
 module "cert_mounter" {
   source = "./.terraform/modules/__v3__/cert_mounter"
 

--- a/src/domains/idpay-app/99_locals.tf
+++ b/src/domains/idpay-app/99_locals.tf
@@ -50,7 +50,6 @@ locals {
     }
   }
 
-  domain_aks_hostname                      = var.env == "prod" ? "${var.instance}.${var.domain}.internal.cstar.pagopa.it" : "${var.instance}.${var.domain}.internal.${var.env}.cstar.pagopa.it"
   rtd_domain_aks_hostname                  = var.env == "prod" ? "${var.instance}.rtd.internal.cstar.pagopa.it" : "${var.instance}.rtd.internal.${var.env}.cstar.pagopa.it"
   rtd_ingress_load_balancer_hostname_https = "https://${local.rtd_domain_aks_hostname}"
   initiative_storage_fqdn                  = "${module.idpay_initiative_storage.name}.blob.core.windows.net"

--- a/src/domains/idpay-app/README.md
+++ b/src/domains/idpay-app/README.md
@@ -64,7 +64,6 @@
 | <a name="module_idpay_wallet_issuer"></a> [idpay\_wallet\_issuer](#module\_idpay\_wallet\_issuer) | ./.terraform/modules/__v3__/api_management_api | n/a |
 | <a name="module_idpay_webview_storage"></a> [idpay\_webview\_storage](#module\_idpay\_webview\_storage) | ./.terraform/modules/__v3__/storage_account | n/a |
 | <a name="module_kubernetes_service_account"></a> [kubernetes\_service\_account](#module\_kubernetes\_service\_account) | ./.terraform/modules/__v3__/kubernetes_service_account | n/a |
-| <a name="module_tls_checker"></a> [tls\_checker](#module\_tls\_checker) | ./.terraform/modules/__v3__/tls_checker | n/a |
 | <a name="module_workload_identity"></a> [workload\_identity](#module\_workload\_identity) | ./.terraform/modules/__v3__/kubernetes_workload_identity_configuration | n/a |
 
 ## Resources

--- a/src/domains/mil-app-poc/.terraform.lock.hcl
+++ b/src/domains/mil-app-poc/.terraform.lock.hcl
@@ -6,6 +6,7 @@ provider "registry.terraform.io/hashicorp/azuread" {
   constraints = "~> 3.1"
   hashes = [
     "h1:DciAAiQWGJK0FR+2Qe/O/NwukMs6nLtVqv19BQY6hU4=",
+    "h1:u/P26g3e4j5QM2i6VkYLFbmMhHlj76kvGfhJQ23BT9Q=",
     "zh:063897b38fd6231577c21a751ccd955716bca0e3abcf800a90dd1dd50fb24875",
     "zh:19704c38c0cf229dc663e36a3ea53649780b7b5ec3953febbc95d7cb5e1cde27",
     "zh:1c3e89cf19118fc07d7b04257251fc9897e722c16e0a0df7b07fcd261f8c12e7",
@@ -25,6 +26,7 @@ provider "registry.terraform.io/hashicorp/azurerm" {
   version     = "4.24.0"
   constraints = "~> 4.0, ~> 4.23"
   hashes = [
+    "h1:HPGpRzmaAhrguNcDn25r1RAu4h0d4b2lq6MTIxiTw6w=",
     "h1:QKLE+6C8K98qAoah9gY6H6twDjpFmujoJsw/uMAGp5Y=",
     "zh:26cebd201fad0c361e757d8552208106b70fd8dbca3668229ae4eb92fcd69d20",
     "zh:33e8929ef07dd515a93027d35b77ad28b9a9fa915d824c028e0df75bcd7ad18a",

--- a/src/domains/mil-app-poc/11_aks_middleware_tools.tf
+++ b/src/domains/mil-app-poc/11_aks_middleware_tools.tf
@@ -1,29 +1,3 @@
-module "tls_checker" {
-  source = "./.terraform/modules/__v4__/tls_checker"
-
-  https_endpoint                                            = local.domain_aks_hostname
-  alert_name                                                = local.domain_aks_hostname
-  alert_enabled                                             = true
-  helm_chart_present                                        = true
-  namespace                                                 = kubernetes_namespace.namespace.metadata[0].name
-  location_string                                           = var.location_string
-  kv_secret_name_for_application_insights_connection_string = "appinsights-instrumentation-key"
-  application_insights_resource_group                       = data.azurerm_resource_group.monitor_rg.name
-  application_insights_id                                   = data.azurerm_application_insights.application_insights.id
-  application_insights_action_group_ids                     = [data.azurerm_monitor_action_group.slack.id, data.azurerm_monitor_action_group.email.id]
-  keyvault_name                                             = data.azurerm_key_vault.kv_domain.name
-  keyvault_tenant_id                                        = data.azurerm_client_config.current.tenant_id
-
-  workload_identity_enabled              = true
-  workload_identity_service_account_name = module.workload_identity.workload_identity_service_account_name
-  workload_identity_client_id            = module.workload_identity.workload_identity_client_id
-
-  depends_on = [
-    module.workload_identity,
-    azurerm_key_vault_secret.appinsights-instrumentation-key
-  ]
-}
-
 module "cert_mounter" {
   source = "./.terraform/modules/__v4__/cert_mounter"
 

--- a/src/domains/mil-app-poc/README.md
+++ b/src/domains/mil-app-poc/README.md
@@ -27,7 +27,6 @@
 | <a name="module_emd_tpp"></a> [emd\_tpp](#module\_emd\_tpp) | ./.terraform/modules/__v4__/api_management_api | n/a |
 | <a name="module_emd_tpp_product"></a> [emd\_tpp\_product](#module\_emd\_tpp\_product) | ./.terraform/modules/__v4__/api_management_product | n/a |
 | <a name="module_kubernetes_service_account"></a> [kubernetes\_service\_account](#module\_kubernetes\_service\_account) | ./.terraform/modules/__v4__/kubernetes_service_account | n/a |
-| <a name="module_tls_checker"></a> [tls\_checker](#module\_tls\_checker) | ./.terraform/modules/__v4__/tls_checker | n/a |
 | <a name="module_workload_identity"></a> [workload\_identity](#module\_workload\_identity) | ./.terraform/modules/__v4__/kubernetes_workload_identity_configuration | n/a |
 
 ## Resources

--- a/src/domains/rtd-app/80_middleware_tools.tf
+++ b/src/domains/rtd-app/80_middleware_tools.tf
@@ -1,26 +1,3 @@
-module "tls_checker" {
-  source = "./.terraform/modules/__v3__/tls_checker"
-
-  https_endpoint                                            = local.domain_aks_hostname
-  alert_name                                                = local.domain_aks_hostname
-  alert_enabled                                             = true
-  helm_chart_present                                        = true
-  namespace                                                 = kubernetes_namespace.domain_namespace.metadata[0].name
-  location_string                                           = var.location_string
-  kv_secret_name_for_application_insights_connection_string = azurerm_key_vault_secret.appinsights-instrumentation-key.name
-  application_insights_resource_group                       = data.azurerm_resource_group.monitor_rg.name
-  application_insights_id                                   = data.azurerm_application_insights.application_insights.id
-  application_insights_action_group_ids                     = [data.azurerm_monitor_action_group.slack.id, data.azurerm_monitor_action_group.email.id]
-  keyvault_tenant_id                                        = data.azurerm_client_config.current.tenant_id
-  keyvault_name                                             = data.azurerm_key_vault.kv.name
-
-  workload_identity_enabled              = true
-  workload_identity_service_account_name = module.workload_identity.workload_identity_service_account_name
-  workload_identity_client_id            = module.workload_identity.workload_identity_client_id
-  depends_on                             = [module.workload_identity]
-}
-
-
 module "cert_mounter" {
   source = "./.terraform/modules/__v3__/cert_mounter"
 

--- a/src/domains/rtd-app/99_locals.tf
+++ b/src/domains/rtd-app/99_locals.tf
@@ -26,8 +26,6 @@ locals {
   system_domain_namespace = kubernetes_namespace.system_domain_namespace.metadata[0].name
   domain_namespace        = kubernetes_namespace.domain_namespace.metadata[0].name
 
-  domain_aks_hostname = var.env == "prod" ? "${var.instance}.${var.domain}.internal.cstar.pagopa.it" : "${var.instance}.${var.domain}.internal.${var.env}.cstar.pagopa.it"
-
   appgw_api_hostname    = var.env_short == "p" ? "api.cstar.pagopa.it" : "api.${var.env}.cstar.pagopa.it"
   appgw_api_io_hostname = var.env_short == "p" ? "api-io.cstar.pagopa.it" : "api-io.${var.env}.cstar.pagopa.it"
 

--- a/src/domains/rtd-app/README.md
+++ b/src/domains/rtd-app/README.md
@@ -32,7 +32,6 @@
 | <a name="module_rtd_senderack_correct_download_ack"></a> [rtd\_senderack\_correct\_download\_ack](#module\_rtd\_senderack\_correct\_download\_ack) | ./.terraform/modules/__v3__/api_management_api | n/a |
 | <a name="module_rtd_senderack_download_file"></a> [rtd\_senderack\_download\_file](#module\_rtd\_senderack\_download\_file) | ./.terraform/modules/__v3__/api_management_api | n/a |
 | <a name="module_rtd_senderadeack_filename_list"></a> [rtd\_senderadeack\_filename\_list](#module\_rtd\_senderadeack\_filename\_list) | ./.terraform/modules/__v3__/api_management_api | n/a |
-| <a name="module_tls_checker"></a> [tls\_checker](#module\_tls\_checker) | ./.terraform/modules/__v3__/tls_checker | n/a |
 | <a name="module_workload_identity"></a> [workload\_identity](#module\_workload\_identity) | ./.terraform/modules/__v3__/kubernetes_workload_identity_configuration | n/a |
 
 ## Resources


### PR DESCRIPTION
### List of changes

- Removed deprecated `tls_checker` module usages across multiple domains.
- Cleaned up references to `domain_aks_hostname` where applicable.
- Updated Terraform lock file to reflect changes.

### Motivation and context

The `tls_checker` module is no longer in use and has been deprecated. Its removal simplifies the codebase and eliminates outdated references.

### Type of changes

- [ ] Add new resources
- [ ] Update configuration to existing resources
- [x] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

#### Has This Been Tested?

- [ ] Yes
- [x] No

### Other information
Target: 
```

```

#### How Has This Been Tested?

N/A - No explicit testing provided for removal.

- [ ] Unit Test Suite
- [ ] Integration Test Suite
- [ ] Api Tests
- [ ] Load Tests

[Link to test results](https://pagopa.atlassian.net/browse/RTD-XXXX)

--- 

### If PR is partially applied, why? (reserved to mantainers)

N