### PR TITLE
feat: [EBE-73] add bonuselettrodomestici.it origin in apim policy

### DIFF
--- a/src/core/99_locals.tf
+++ b/src/core/99_locals.tf
@@ -45,6 +45,7 @@ locals {
   apim_hostname    = "api${local.hostname_suffix}"
   rtp_endpoint     = "https://rtp${local.hostname_suffix}"
   welfare_endpoint = "https://welfare${local.hostname_suffix}"
+  bonuselettrodomestici_endpoint = "https://${var.bonus_elettrodomestici_hostname}"
 
   azdo_managed_identity_rg_name = "${var.prefix}-${var.env_short}-identity-rg"
   azdo_iac_managed_identities   = toset(["azdo-${var.env}-${var.prefix}-iac-deploy-v2", "azdo-${var.env}-${var.prefix}-iac-plan-v2"])

--- a/src/core/99_locals.tf
+++ b/src/core/99_locals.tf
@@ -41,10 +41,10 @@ locals {
 
   hostname_suffix = "%{if var.env_short == "p"}.%{else}.${var.env}.%{endif}cstar.pagopa.it"
 
-  apim_name        = "${local.project}-apim"
-  apim_hostname    = "api${local.hostname_suffix}"
-  rtp_endpoint     = "https://rtp${local.hostname_suffix}"
-  welfare_endpoint = "https://welfare${local.hostname_suffix}"
+  apim_name                      = "${local.project}-apim"
+  apim_hostname                  = "api${local.hostname_suffix}"
+  rtp_endpoint                   = "https://rtp${local.hostname_suffix}"
+  welfare_endpoint               = "https://welfare${local.hostname_suffix}"
   bonuselettrodomestici_endpoint = "https://${var.bonus_elettrodomestici_hostname}"
 
   azdo_managed_identity_rg_name = "${var.prefix}-${var.env_short}-identity-rg"

--- a/src/core/99_variables.tf
+++ b/src/core/99_variables.tf
@@ -879,3 +879,9 @@ variable "srtp_enable_itn_rewrite" {
   description = ""
   default     = "false"
 }
+
+variable "bonus_elettrodomestici_hostname" {
+  type        = string
+  description = ""
+  default     = "false"
+}

--- a/src/core/README.md
+++ b/src/core/README.md
@@ -337,6 +337,7 @@
 | <a name="input_azdoa_image_name"></a> [azdoa\_image\_name](#input\_azdoa\_image\_name) | Azure DevOps Agent image name for scaleset | `string` | n/a | yes |
 | <a name="input_backupstorage_account_replication_type"></a> [backupstorage\_account\_replication\_type](#input\_backupstorage\_account\_replication\_type) | Account replication type | `string` | n/a | yes |
 | <a name="input_bkp_sa_soft_delete"></a> [bkp\_sa\_soft\_delete](#input\_bkp\_sa\_soft\_delete) | Set Retention Days of Deleted Blob and Containers on Backup Storage Account | <pre>object({<br/>    blob      = number<br/>    container = number<br/>  })</pre> | <pre>{<br/>  "blob": 7,<br/>  "container": 7<br/>}</pre> | no |
+| <a name="input_bonus_elettrodomestici_hostname"></a> [bonus\_elettrodomestici\_hostname](#input\_bonus\_elettrodomestici\_hostname) | n/a | `string` | `"false"` | no |
 | <a name="input_cdc_api_params"></a> [cdc\_api\_params](#input\_cdc\_api\_params) | n/a | <pre>object({<br/>    host = string<br/>  })</pre> | <pre>{<br/>  "host": "https://httpbin.org"<br/>}</pre> | no |
 | <a name="input_cidr_integration_vnet"></a> [cidr\_integration\_vnet](#input\_cidr\_integration\_vnet) | Virtual network to peer with sia subscription. It should host apim and event hub. | `list(string)` | n/a | yes |
 | <a name="input_cidr_pair_vnet"></a> [cidr\_pair\_vnet](#input\_cidr\_pair\_vnet) | Virtual network address space. | `list(string)` | n/a | yes |

--- a/src/core/api.tf
+++ b/src/core/api.tf
@@ -61,7 +61,8 @@ module "apim" {
       "https://${local.portal_domain}",
       "https://${local.management_domain}",
       local.rtp_endpoint,
-      local.welfare_endpoint
+      local.welfare_endpoint,
+      local.bonuselettrodomestici_endpoint
     ]
   }))
 

--- a/src/core/env/dev/terraform.tfvars
+++ b/src/core/env/dev/terraform.tfvars
@@ -392,3 +392,5 @@ operations_logs_account_replication_type = "GRS"
 internal_ca_intermediate = "06"
 
 srtp_enable_itn_rewrite = true
+
+bonus_elettrodomestici_hostname = "dev.bonuselettrodomestici.it"

--- a/src/core/env/prod/terraform.tfvars
+++ b/src/core/env/prod/terraform.tfvars
@@ -386,3 +386,6 @@ backupstorage_account_replication_type   = "RAGZRS"
 operations_logs_account_replication_type = "RAGZRS"
 
 internal_ca_intermediate = "07"
+
+bonus_elettrodomestici_hostname = "bonuselettrodomestici.it"
+

--- a/src/core/env/uat/terraform.tfvars
+++ b/src/core/env/uat/terraform.tfvars
@@ -389,3 +389,5 @@ backupstorage_account_replication_type   = "GRS"
 operations_logs_account_replication_type = "GRS"
 
 internal_ca_intermediate = "06"
+
+bonus_elettrodomestici_hostname = "uat.bonuselettrodomestici.it"


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
This PR proposes to add the bonuselettrodomestici.it domain into the allowed origins of apim global policy
### List of changes

<!--- Describe your changes in detail -->

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

#### Has This Been Tested?

- [x] Yes
- [ ] No

### Other information
Target: 
```
-target=module.apim
```

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] Unit Test Suite
- [ ] Integration Test Suite
- [ ] Api Tests
- [ ] Load Tests

<!-- Provide screenshot or link to test results-->
[Link to test results](https://pagopa.atlassian.net/browse/RTD-XXXX)

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
